### PR TITLE
fix: keep Spanish preface links valid

### DIFF
--- a/book/preface-ES.md
+++ b/book/preface-ES.md
@@ -102,7 +102,7 @@ mejorar y enseñar.
 ## Empieza por un problema real
 
 Si no quieres leer en orden, elige un capítulo desde el [índice del libro en
-español](table-of-contents-ES.md) y entra después
+español (migración ES en curso; fuente actual)](table-of-contents.md) y entra después
 en los casos de problemas reales, la especificación de fixtures de evaluación
 y el archivo de investigación que ese capítulo enumera. Los capítulos 19–22
 siguen en estado `draft` —el texto está escrito, pero espera la prueba previa—
@@ -111,6 +111,6 @@ y los recorridos de evaluación que aún no tienen registros permanecen en
 significan que el capítulo o la evaluación ya hayan sido verificados.
 
 Para volver a la guía del manuscrito en español, usa la [entrada del libro en
-español](README-ES.md). Los destinos locales que todavía no tienen una
+español (migración ES en curso; fuente actual)](README.md). Los destinos locales que todavía no tienen una
 variante `-ES` llevan la marca «migración ES en curso» para distinguir
 honestamente la fuente compartida de una traducción disponible.


### PR DESCRIPTION
## Problem
The latest `main` quality workflow failed in `Check local Markdown links` because `book/preface-ES.md` points to `book/table-of-contents-ES.md` and `book/README-ES.md`, but those localized entry files are not present in the committed base tree.

## Fix
Keep the Spanish preface links honest and valid during the locale migration by linking to the existing shared source files and labeling them as the current source.

## Validation
- `python scripts/check_local_links.py`
- `python scripts/validate_project.py`
- `python scripts/audit_input_archives.py`
- `git diff --check`

All passed locally. AI assistance was used for the patch; I reviewed the changed link targets and validation output.