### PR TITLE
fix: invalidate homepage style cache

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -34,7 +34,7 @@
     <title>Prysai LLM Playbook — LLM Guide, Prompts, and Reliable AI Work</title>
     <script type="application/ld+json" id="site-structured-data">{"@context":"https://schema.org","@type":"WebSite","name":"Prysai LLM Playbook","alternateName":"LLMPlaybook","url":"https://docs.prysai.com/llm-playbook/","description":"Learn what LLMs are, write clearer prompts, and turn a first AI task into bounded, checkable work before choosing a platform-specific track.","inLanguage":["en","zh-CN","es","ja","ko","de","zh-TW"],"isAccessibleForFree":true}</script>
     <link rel="icon" type="image/png" href="../assets/branding/prysai-lab-mark-black-96.png" />
-    <link rel="stylesheet" href="styles.css?v=20260815-mobile-viewport" />
+    <link rel="stylesheet" href="styles.css?v=20260818-mobile-hero" />
     <script src="locale-manifest.js?v=20260813-integrity"></script>
     <script src="learning-path-data.js?v=20260813-integrity"></script>
     <script src="goal-templates.js?v=20260816"></script>


### PR DESCRIPTION
## Summary\n- invalidate the homepage stylesheet cache after the mobile hero refinement\n- preserve the mobile regression coverage from the parent PR\n\n## Verification\n- Parent PR #6: mobile hero style change\n- Parent PR #7: 390px regression guard\n- This PR updates only the cache-busting query string so deployed clients receive the corrected stylesheet.\n\nDepends on #7. Please merge #6, then #7, then this PR in order.