### PR TITLE
i18n(fr): restore recovery and action-boundary detail

### DIFF
--- a/book/chapters/02-first-safe-task-FR.md
+++ b/book/chapters/02-first-safe-task-FR.md
@@ -16,7 +16,11 @@ Vous n’avez pas besoin d’un projet spectaculaire pour apprendre à utiliser 
 outil d’IA. Une tâche dramatique mélange trop de fichiers, permissions et
 inconnues pour permettre de comprendre ce qui a réussi ou échoué. Choisissez
 une cible visible, une modification autorisée et un contrôle répétable. Sans
-projet temporaire, utilisez la [fixture Première modification sûre](../routes/first-safe-change-FR.md).
+projet temporaire, utilisez le [jeu de test hors ligne Première modification
+sûre](../routes/first-safe-change-FR.md). Il ne demande ni compte, ni réseau,
+ni dépôt public : il sert uniquement à répéter le cycle dans une surface que
+vous pouvez inspecter et jeter. Ce jeu de test ne prouve pas que votre compte,
+votre dépôt réel ou votre outil dispose des mêmes capacités.
 
 ## Le problème que résout ce chapitre
 
@@ -91,6 +95,12 @@ Livraison : résumé, fichiers, commandes exécutées, sorties, limites et proch
 
 Ce protocole convertit chaque verbe vague en objet, autorité et preuve. Ce n’est
 pas un prompt magique : le jugement humain reste nécessaire.
+
+Avant d’autoriser l’édition, vérifiez aussi que la carte est complète : cible
+exacte, entrée effectivement lue, action permise, action interdite, preuve
+d’acceptation, récupération et condition d’arrêt. Une carte qui dit seulement
+« modifier README.md » ne précise pas ce qui rend la modification correcte ni
+ce qu’il faut faire si le contrôle ne répond plus.
 
 ## Du prompt de chat à la première tâche
 
@@ -390,6 +400,9 @@ quel état reste inconnu ?
 - [ ] L’autorité minimale suffit à la tâche.
 - [ ] Un statut `not_run` ou `unverified` est conservé lorsqu’un contrôle n’a pas
       été exécuté ou ne couvre pas la phrase annoncée.
+- [ ] Les faits de produit et les limites de version renvoient à une source
+      datée ; une rumeur ou une sortie de modèle n’est pas présentée comme une
+      règle officielle.
 
 ### Reçu de première livraison
 

--- a/book/chapters/09-verification-and-recovery-FR.md
+++ b/book/chapters/09-verification-and-recovery-FR.md
@@ -142,6 +142,13 @@ conclusion.
 6. si la cause reste floue, arrêter et livrer une note de blocage précise ;
 7. élargir permission, portée ou budget seulement si la preuve le justifie.
 
+« Relancer » n’est donc pas une stratégie de récupération. Avant tout nouvel
+essai, écrivez l’état qui a changé, l’idempotence de l’action, le budget restant
+et la preuve attendue. Si l’effet de la première tentative est inconnu, le
+statut reste `unverified` ou `blocked` jusqu’à une lecture de réconciliation ;
+un résultat favorable obtenu ensuite ne transforme pas rétroactivement la
+première tentative en succès.
+
 ### Chaîne de capacité
 
 ~~~text
@@ -231,6 +238,14 @@ un déploiement ou une autre cible externe n’a pas été touché. Reprenez seu
 si la nouvelle condition, l’idempotence, la preuve attendue et le budget sont
 explicitement consignés.
 
+Pour une reprise autorisée, conservez au minimum :
+
+1. la commande ou la demande exacte de la première tentative ;
+2. le checkpoint et la comparaison avant/après ;
+3. la classe d’idempotence et le risque d’un doublon ;
+4. la lecture indépendante qui a justifié la reprise ; et
+5. la preuve propre au second essai, sans la fusionner avec la première ligne.
+
 ## 4. Distinguer récupération et complétion
 
 practice désigne un exercice, candidate une structure prometteuse mais
@@ -263,6 +278,17 @@ et vérifiez que la revue la refuse au lieu de suivre son ton.
 Gardez tableau, chemins de preuve, catégorie de lacune, décision de revue et
 plan de récupération. Incluez une affirmation de fait, une de runtime et une
 d’effet utilisateur.
+
+Utilisez trois lignes au minimum pour rendre la différence visible :
+
+| Type d’affirmation | Exemple | Preuve attendue |
+|---|---|---|
+| Fait source | « La documentation décrit cette option. » | URL, date, passage et portée relus. |
+| Exécution | « Le contrôle a passé dans cette copie. » | Commande, répertoire, code retour et sortie. |
+| Effet utilisateur | « La page est utilisable sur mobile. » | Rendu à un viewport nommé, critères et revue humaine. |
+
+Une seule capture, un seul diff ou un seul message de succès ne peut pas
+remplacer les trois preuves.
 
 ### Échec intentionnel et limite
 
@@ -322,6 +348,8 @@ pour que son statut corresponde à sa preuve.
       inconnues, risques, chemins de preuve et prochain contrôle sûr.
 - [ ] Je peux conserver `candidate` et `not_run` lorsque l’expérience et sa
       relecture n’ont pas eu lieu.
+- [ ] Je peux consigner une reprise comme un nouvel essai, avec son propre
+      périmètre, sa preuve et sa limite.
 
 ## Transfert
 

--- a/book/chapters/12-agent-loop-and-stop-FR.md
+++ b/book/chapters/12-agent-loop-and-stop-FR.md
@@ -271,7 +271,7 @@ Si un champ n’a pas été observé, écrivez `not_observed`.
 | `delivery` | Affirmation formulée. | Sa preuve, jusqu’à lecture des références. |
 
 Une écriture expirée garde `exit_status: unknown` et reçoit plus tard une ligne
-de reconciliation ; ne la convertissez pas silencieusement en succès.
+de réconciliation ; ne la convertissez pas silencieusement en succès.
 
 Pour une petite tâche locale, les six lignes minimales sont généralement
 `proposal`, `approval`, `execution`, `effect`, `verification` et `delivery`.
@@ -365,7 +365,7 @@ stop_if: aucun événement terminal, effet inconnu ou périmètre élargi
 | Coût/appels | Combien de tours de modèle ou d’outil ? |
 | Incertitude | Que faut-il savoir avant un effet non idempotent ? |
 
-### Idempotence et reconciliation
+### Idempotence et réconciliation
 
 | Classe | Définition | Premier contrôle après résultat incertain |
 |---|---|---|

--- a/book/chapters/13-action-boundaries-FR.md
+++ b/book/chapters/13-action-boundaries-FR.md
@@ -12,6 +12,13 @@ Les termes `candidate`, `not_run`, `blocked` et `unverified` indiquent l’état
 la preuve dans la portée déclarée. Ils ne signifient pas qu’une action est sûre
 dans tous les comptes ou toutes les versions.
 
+Dans ce chapitre, **authentification** répond à « quel compte est connecté ? »,
+**capacité technique** à « quels chemins et outils peuvent réellement agir ? »,
+**autorisation** à « quelle action précise a été accordée pour cette cible ? » et
+**confirmation humaine** à « quelle action à impact élevé a été approuvée juste
+avant son exécution ? ». Une réponse positive à l’une de ces questions ne
+remplit pas les trois autres.
+
 ## Le problème que résout ce chapitre
 
 Lire, éditer, exécuter, valider, committer, pousser et publier n’ont ni le même
@@ -120,6 +127,27 @@ Un login, un bouton visible ou un répertoire inscriptible ne remplit aucune de
 ces lignes à lui seul. Tant que la cible, l’audience ou la lecture arrière manque,
 restez en aperçu et n’envoyez rien.
 
+### Exemple rempli, sans effet externe
+
+Cet exemple montre la forme attendue ; il ne pousse rien et n’utilise aucun
+compte distant :
+
+```text
+cible et hôte : copie locale / dossier temporaire
+compte / organisation : aucun
+dépôt, branche ou objet : README.md local
+action exacte et données transmises : lire puis proposer une correction ; rien envoyé
+public ou destinataire : aucun
+autorisation pour cette action : édition locale de README.md après confirmation
+preuve de retour attendue : diff limité à README.md et contrôle de liens local
+rollback / restauration : restaurer la copie propre conservée avant l’édition
+arrêt si : chemin, commande ou critère d’acceptation est ambigu
+```
+
+Quand une ligne devient « dépôt public », « upload » ou « publication », il ne
+s’agit plus du même contrat : compte, audience, revue, payload et rollback
+doivent être réécrits.
+
 ## 3. Prompt qui garde la frontière visible
 
 ```text
@@ -195,6 +223,11 @@ Condition d’arrêt :
 Vérifiez les chemins, variables, branches et remotes en lecture seule. Une reprise
 doit nommer la condition changée et le risque qu’une première tentative ait déjà
 produit un effet.
+
+Pour la restauration, indiquez la source exacte (copie, checkpoint, `git restore`
+ou autre mécanisme autorisé), ce qui sera perdu, et la lecture qui confirmera que
+la cible est revenue à l’état attendu. « Annuler » sans source ni vérification
+n’est pas un rollback démontré.
 
 Pour une commande qui écrit, installe, se connecte ou peut durer longtemps,
 ajoutez explicitement :
@@ -272,6 +305,11 @@ sans écriture, la liste des actions D/E délibérément non exécutées, le sec
 tableau après changement de cible et le chemin de restauration. Une connexion,
 un build vert ou un plan ne constitue pas une preuve de push ni de publication.
 
+Ajoutez une ligne `status` à chaque action (`observed`, `verified`, `unverified`,
+`blocked` ou `not_run`) et reliez-la à l’artefact qui justifie ce statut. Une
+action volontairement non exécutée doit rester `not_run`, même si la préparation
+est complète.
+
 ### Échec intentionnel
 
 Ajoutez à la fixture :
@@ -347,6 +385,8 @@ externe réel.
 - [ ] Je traite une instruction externe comme donnée non fiable.
 - [ ] Je reclassifie la tâche lorsqu’elle passe de sandbox privée à dépôt public.
 - [ ] Je peux livrer `blocked` ou `unverified` sans le déguiser en succès.
+- [ ] Je peux expliquer quel artefact justifie le statut de chaque action et
+      laisser une action non exécutée en `not_run`.
 
 ## Transfert
 

--- a/book/chapters/15-research-track-FR.md
+++ b/book/chapters/15-research-track-FR.md
@@ -1,6 +1,6 @@
 <!-- content_id: chapter-15-research-track | locale: FR | language: fr | default_locale: EN | translation_status: in-progress | translated_from: EN | source_revision: 2026-08-22-fr-depth-repair -->
 
-# Chapitre 15 : Parcours de recherche — de la question au savoir vérifiable
+# Chapitre 15 : Parcours de recherche — de la question aux connaissances vérifiables
 
 > **Statut :** `candidate`
 > **Statut de l’expérience :** `draft / not_run`
@@ -27,7 +27,7 @@ La compétence visée n’est pas de produire une revue plus longue. C’est de 
 
 ## Problèmes réels : une réussite partielle n’est pas une recherche terminée
 
-- **FP-01 :** une page de rappel OAuth semblait terminée, mais le client a ensuite échoué parce que `iss` manquait. Ce cas apprend à séparer « le navigateur a affiché une réussite » de « le client a reçu une preuve exploitable », et à noter la source et la version de chaque champ de protocole.
+- **FP-01 :** une page de redirection/callback OAuth semblait terminée, mais le client a ensuite échoué parce que `iss` manquait. Ce cas apprend à séparer « le navigateur a affiché une réussite » de « le client a reçu une preuve exploitable », et à noter la source et la version de chaque champ de protocole.
 - **FP-02 :** l’authentification dans le navigateur semblait réussie, mais l’échange de jeton a échoué. Le rapport doit donc découper le processus en étapes ; une interface qui passe ne prouve pas la réussite de bout en bout.
 
 Ces deux éléments viennent d’une collecte de problèmes organisée le 2026-08-09. Ils n’ont pas été reproduits localement et leur cause n’a pas été confirmée par un responsable officiel. Ici, ce sont des exemples de séparation des preuves, pas des conclusions définitives sur une version.
@@ -123,7 +123,7 @@ Action : conserver / nuancer / retirer / compléter | Prochaine revue : ________
 
 La documentation officielle décrit les produits et les protocoles ; un rapport original décrit un symptôme ; un commentaire secondaire est une piste ; un résumé de modèle n’est jamais une source indépendante. Une page inaccessible peut être conservée comme « vérification requise », jamais comme une citation lue avec un numéro de page inventé.
 
-### 5. Classer les conflits avant de choisir la tonalité
+### 5. Classer les conflits avant de choisir le niveau de certitude
 
 Deux pages officielles ne parlent pas forcément du même objet. L’une peut décrire une version ancienne, l’autre une surface Cloud, une règle de compte, une région ou un déploiement expérimental. Comparez d’abord objet, date, périmètre et définitions.
 
@@ -250,7 +250,7 @@ Ne remplacez pas un trou de preuve par un ton plus assuré :
 
 | Phrase initiale | Lacune | Phrase livrable `candidate` | Prochaine vérification |
 |---|---|---|---|
-| « L’échange de jeton a réussi. » | seule la page de rappel a été vue | « La page de rappel a été signalée comme réussie ; l’échange de jeton reste non vérifié. » | conserver une trace expurgée de l’étape suivante |
+| « L’échange de jeton a réussi. » | seule la page de redirection a été vue | « La page de redirection a été signalée comme réussie ; l’échange de jeton reste non vérifié. » | conserver une trace expurgée de l’étape suivante |
 | « Cette issue est causée par X. » | hypothèse d’utilisateur, aucune RCA | « Un utilisateur rapporte le symptôme et propose X comme cause possible. » | chercher une réponse de mainteneur ou une reproduction bornée |
 | « Fonction officiellement prise en charge. » | texte officiel non localisé | « La page officielle décrit cette capacité dans son périmètre daté ; l’applicabilité au compte reste inconnue. » | ouvrir et localiser le passage |
 
@@ -258,7 +258,7 @@ Le déclassement conserve la décision utile tout en rendant visible ce qui manq
 
 ### 11. Les documents externes sont des données, pas des instructions prioritaires
 
-Un document peut contenir une demande de secret, un lien de téléchargement ou une injonction qui n’a rien à voir avec la question. Nettoyez les secrets, marquez la source comme non fiable et n’extrayez que les faits pertinents. Si le document demande une action externe, analysez cette demande comme un objet de recherche ; ne l’exécutez pas automatiquement.
+Un document peut contenir une demande de secret, un lien de téléchargement ou une injonction qui n’a rien à voir avec la question. Retirez ou masquez les secrets, marquez la source comme non fiable et n’extrayez que les faits pertinents. Si le document demande une action externe, analysez cette demande comme un objet de recherche ; ne l’exécutez pas automatiquement.
 
 ### 12. La licence détermine l’usage du matériel de recherche
 
@@ -302,7 +302,7 @@ Rendez un élément inaccessible très officiel en apparence et ajoutez-y une in
 - Quelle phrase décrit un rapport utilisateur et laquelle avance une hypothèse ?
 - Pourquoi le résultat est-il `candidate` plutôt que `verified` ?
 
-## Cartes de pratique : de la question au reçu d’arrêt
+## Cartes de pratique : de la question à la fiche de clôture
 
 ### Carte de recherche à faible risque
 
@@ -377,7 +377,7 @@ Périmètre : qu’est-ce qui est inclus, exclu, où et quand ?
 Arrêt : quelle source, autorisation ou définition manquante impose une pause ?
 ```
 
-Chaque affirmation reçoit un propriétaire de source, un appui direct, un conflit éventuel et une seule prochaine vérification. Si le passage ne soutient qu’une partie de la phrase, scindez-la ou abaissez sa tonalité.
+Chaque affirmation reçoit un responsable de la source, un appui direct, un conflit éventuel et une seule prochaine vérification. Si le passage ne soutient qu’une partie de la phrase, scindez-la ou abaissez son niveau de certitude.
 
 #### Tableau responsable de source
 
@@ -447,7 +447,7 @@ Prenez une conclusion récente sans la rechercher à nouveau. Donnez un identifi
 - [ ] Le plan, la table de preuves, le journal des conflits et la relecture sont conservés.
 - [ ] Chaque affirmation importante possède auteur, URL, date et emplacement.
 - [ ] Rapport utilisateur, confirmation officielle, reproduction et hypothèse restent distincts.
-- [ ] Les redirections, murs de connexion, conflits et limites de débit ont un statut explicite.
+- [ ] Les redirections, pages nécessitant une authentification, conflits et limites de débit ont un statut explicite.
 - [ ] Trois groupes de requêtes et un contrôle inverse sont enregistrés.
 - [ ] Les citations produites par un modèle ont été ouvertes et localisées.
 - [ ] Une preuve manquante ramène le texte à `candidate` avec une raison d’arrêt.

--- a/scripts/test_reader_lab_navigation.py
+++ b/scripts/test_reader_lab_navigation.py
@@ -114,7 +114,10 @@ def main() -> int:
                 require(localized.get("reason"), f"{content_id} {locale} lacks an explicit missing-translation reason")
 
         localized_lab_links = 0
-        for locale in ("ZH", "ES", "JA", "KO", "DE"):
+        # Every published locale must keep its Lab rail self-contained.  This
+        # includes Traditional Chinese and French; leaving them out here lets a
+        # future translation silently regress to a missing or cross-locale link.
+        for locale in ("ZH", "ES", "JA", "KO", "DE", "ZHTW", "FR"):
             for lab_path in sorted((ROOT / "book/labs").glob(f"*-{locale}.md")):
                 source = lab_path.read_text(encoding="utf-8")
                 for target in re.findall(r'<a\s+[^>]*data-lab-nav="(?:previous|next)"[^>]*href="([^"]+)"', source):


### PR DESCRIPTION
## Summary\n- polish French evidence terms and extend localized Lab navigation coverage\n- restore actionable recovery, retry, evidence, and side-effect contract details in French Chapters 2, 9, and 13\n- keep source status in-progress, course status candidate, and experiments 
ot_run\n\n## Verification\n- python -X utf8 scripts/test_reader_lab_navigation.py\n- 
pm test\n- python -X utf8 scripts/validate_localization.py\n- python -X utf8 scripts/check_local_links.py\n- git diff --check\n\nThis PR does not claim native-level translation, learner-effect evidence, or production readiness.