### PR TITLE
feat(reader): strengthen multilingual visual reading path

### DIFF
--- a/docs/quality/reader-research-visual-sequence-2026-08-25.md
+++ b/docs/quality/reader-research-visual-sequence-2026-08-25.md
@@ -1,0 +1,42 @@
+<!-- content_id: reader-research-visual-sequence-2026-08-25 | kind: quality-record | status: candidate | owner: site-maintainer | reviewed: 2026-08-25 -->
+
+# Reader research visual sequence — 2026-08-25
+
+This record covers the addition of the evidence-maturity ladder to the
+research route's related visual sequence. It records route and rendering
+checks; it does not establish translation quality, learner comprehension,
+transfer, independent review, or release readiness.
+
+## Change
+
+- `site/reader.js` now supplies localized title, next-question, and evidence-
+  boundary copy for `evidence-maturity-ladder-red-black.svg` in all eight
+  registered Reader locales.
+- Chapter 15, Lab 008, and Lab 015 now include that board in the related visual
+  sequence. The existing two-card Reader presentation remains bounded to two
+  related cards, so the new board replaces no primary visual and does not turn
+  the Reader into an unstructured gallery.
+- `scripts/reader_visual_smoke.mjs` now checks Chapter 15 in all eight locales,
+  including discoverability of the ladder, non-empty alternative text, an
+  evidence boundary, and no horizontal overflow at 390px.
+
+## Verification
+
+| Check | Result | Scope |
+| --- | --- | --- |
+| JavaScript syntax and whitespace | passed | `site/reader.js`, `scripts/reader_visual_smoke.mjs`, `git diff --check` |
+| Reader visual smoke | passed | Lab 003 in 8 locales; Chapter 15 in 8 locales; 390px overflow guard |
+| Teaching asset catalog | passed | 42 project-owned SVG boards, source register, mobile inventory, and SVG text alternatives |
+| Project validators | passed | project, structure, content completeness, and canonical-EN learning contract |
+| Semantic contract audit | passed with 10 attention signals | 320 files; `missing_contract=0`, `deep_missing=0`; compression signals are pre-existing review prompts |
+| Regression suite | passed | `npm test`; 49 tests passed |
+| Visual guide smoke | passed | 8 locales, 20 boards, 390px and 360px, no-script fallbacks |
+
+## Evidence boundary
+
+The ladder separates designed, rendered, practiced, transferred, and
+independently reviewed evidence. Adding it to the Reader improves discovery of
+that distinction; it does not move this project to a higher evidence stage.
+The full browser smoke suite remains separately tracked because its latest
+rerun timed out after the focused checks, so this record must not be read as a
+production or deployment claim.

--- a/docs/quality/visual-guide-smoke-2026-08-25.md
+++ b/docs/quality/visual-guide-smoke-2026-08-25.md
@@ -35,10 +35,12 @@ python -X utf8 scripts/run_tests.py
 | No-script fallback | passed | English ordered text fallbacks for every interactive visual route |
 | Repository validators | passed | project, structure, content completeness, learning contract, and site i18n |
 | Regression suite | passed | `script_tests=48 passed=49 failed=0` |
-| Full browser smoke | passed | the independent `scripts/browser_smoke.mjs` rerun completed with exit code 0 after the focused viewer checks |
+| Full browser smoke | historical pass; current rerun timed out | An earlier run recorded exit code 0 after the focused viewer checks. The 2026-08-25 rerun reached the 240-second guard without a new assertion stack, so this remains an open investigation rather than current pass evidence. |
 
-The focused command is intentionally narrower than the full browser smoke. It
-is a fast regression signal for the visual guide and viewer. The Reader action
-note and Traditional Chinese mobile render were also checked with a local
-Playwright run, followed by an independent full browser smoke pass. These
-checks are not a substitute for deployment propagation or learner checks.
+The focused commands are intentionally narrower than the full browser smoke.
+They are fast regression signals for the visual guide, viewer, and Lab 003
+Reader route. The Reader action note and Traditional Chinese mobile render
+were also checked with a local Playwright run. The full browser suite retains a
+historical pass record, but its latest rerun timed out and needs a separate
+performance investigation before it can be treated as current evidence. None
+of these checks substitute for deployment propagation or learner checks.

--- a/docs/quality/visual-guide-smoke-2026-08-25.md
+++ b/docs/quality/visual-guide-smoke-2026-08-25.md
@@ -12,6 +12,7 @@ readiness.
 ```text
 python -X utf8 scripts/build_pages_artifact.py --output _site
 npm run test:visuals
+npm run test:reader-visuals
 python -X utf8 scripts/validate_project.py
 python -X utf8 scripts/validate_project_structure.py
 python -X utf8 scripts/validate_content_completeness.py
@@ -25,7 +26,8 @@ python -X utf8 scripts/run_tests.py
 | Check | Result | Scope |
 | --- | --- | --- |
 | Candidate Pages build | passed | `_site/` generated from the current source tree |
-| Focused visual smoke | passed | 8 locale routes; 19 boards; dynamic route, goal, journey, capability, maturity, concept, evidence, receipt, reading-loop, action-boundary, and triage nodes |
+| Focused visual smoke | passed | 8 locale routes; 20 boards; dynamic route, goal, journey, capability, maturity, concept, evidence, receipt, reading-loop, action-boundary, and triage nodes |
+| Lab 003 Reader visual smoke | passed | 8 locale routes; localized heading, experiment-record board, alternative text, text explanation, evidence boundary, related visuals, and 390px overflow check |
 | Responsive visual viewer | passed | Approved board links use the project viewer with localized labels, zoom controls, raw-SVG escape hatch, and rejected-asset error state |
 | Reader visual action note | passed | Localized `look first / do next / keep / do not infer` strip rendered in English, Simplified Chinese, Spanish, Japanese, Korean, German, Traditional Chinese, and French |
 | Mobile overflow | passed | 390px and 360px visual guide viewports |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "python scripts/run_tests.py",
     "test:browser": "node scripts/browser_smoke.mjs",
+    "test:reader-visuals": "node scripts/reader_visual_smoke.mjs",
     "test:visuals": "node scripts/visual_guide_smoke.mjs",
     "audit:translations": "python -X utf8 scripts/audit_translation_language_quality.py --verbose"
   },

--- a/scripts/reader_visual_smoke.mjs
+++ b/scripts/reader_visual_smoke.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const playwrightModule = await import('playwright');
+const { chromium } = playwrightModule.default ?? playwrightModule;
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const artifact = path.join(root, '_site');
+const python = process.env.PYTHON || 'python';
+const locales = [
+  ['en', 'EN', 'Lab 003: Audit a completion claim', 'Keep a lab run small enough to check'],
+  ['zh', 'ZH', '实验 003：审计一条完成声明', '让实验记录小到可以检查'],
+  ['es', 'ES', 'Lab 003: Auditar una declaración de finalización', 'Mantén el experimento lo bastante acotado para comprobarlo'],
+  ['ja', 'JA', 'Lab 003：完了宣言を監査する', '確認できる大きさに実験を絞る'],
+  ['ko', 'KO', 'Lab 003: 완료 주장을 감사하기', '확인할 수 있을 만큼 실험 범위를 줄이기'],
+  ['de', 'DE', 'Lab 003: Eine Fertigmeldung prüfen', 'Einen Versuch so klein halten, dass er prüfbar bleibt'],
+  ['zh-tw', 'ZHTW', '實驗 003：審計一條完成宣告', '把實驗縮小到可以檢查'],
+  ['fr', 'FR', 'Lab 003 : Auditer une affirmation de fin', 'Garder un essai assez petit pour être vérifiable'],
+];
+const documentLanguages = { zh: 'zh-CN', 'zh-tw': 'zh-TW' };
+
+const build = spawnSync(python, ['-X', 'utf8', 'scripts/build_pages_artifact.py', '--output', artifact], {
+  cwd: root,
+  encoding: 'utf8',
+});
+assert.equal(build.status, 0, `Pages candidate build failed:\n${build.stdout}\n${build.stderr}`);
+
+const server = createServer((request, response) => {
+  const requestPath = decodeURIComponent((request.url || '/').split('?')[0]);
+  const relative = requestPath === '/' ? 'index.html' : requestPath.replace(/^\/+/, '');
+  const filePath = path.resolve(artifact, relative);
+  if (!filePath.startsWith(`${artifact}${path.sep}`)) {
+    response.writeHead(400).end();
+    return;
+  }
+  readFile(filePath)
+    .then((body) => {
+      const contentType = filePath.endsWith('.html') ? 'text/html; charset=utf-8'
+        : filePath.endsWith('.js') ? 'text/javascript; charset=utf-8'
+          : filePath.endsWith('.css') ? 'text/css; charset=utf-8'
+            : filePath.endsWith('.svg') ? 'image/svg+xml'
+              : 'application/octet-stream';
+      response.writeHead(200, { 'content-type': contentType });
+      response.end(body);
+    })
+    .catch(() => response.writeHead(404).end());
+});
+
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const address = server.address();
+const origin = `http://127.0.0.1:${address.port}`;
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ viewport: { width: 390, height: 844 } });
+const page = await context.newPage();
+
+const noHorizontalOverflow = async (label) => {
+  const metrics = await page.evaluate(() => ({
+    innerWidth: window.innerWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  assert.ok(metrics.scrollWidth <= metrics.innerWidth, `${label} has horizontal overflow: ${JSON.stringify(metrics)}`);
+};
+
+try {
+  for (const [locale, suffix, heading, thesis] of locales) {
+    await page.goto(`${origin}/site/reader.html?path=book%2Flabs%2Flab-003-evidence-review-${suffix}.md&lang=${locale}`, { waitUntil: 'networkidle' });
+    await page.locator('[data-reader-article][aria-busy="false"] h1').waitFor();
+    assert.equal(await page.locator('html').getAttribute('lang'), documentLanguages[locale] || locale, `${locale} Reader changed the document language`);
+    assert.equal((await page.locator('[data-reader-article] h1').innerText()).trim(), heading, `${locale} Lab 003 heading is not localized`);
+
+    const visual = page.locator('[data-reader-inline-visual]');
+    assert.equal(await visual.count(), 1, `${locale} Lab 003 is missing its inline teaching visual`);
+    assert.match(await visual.getAttribute('data-reader-inline-visual') || '', /experiment-record-anatomy-red-black\.svg$/, `${locale} Lab 003 selected the wrong teaching visual`);
+    assert.equal((await visual.locator('.reader-visual-thesis').innerText()).includes(thesis), true, `${locale} Lab 003 visual thesis is not localized`);
+    assert.notEqual((await visual.locator('img').getAttribute('alt') || '').trim(), '', `${locale} Lab 003 visual has no alternative text`);
+    assert.match(await visual.locator('img').getAttribute('src') || '', /assets\/teaching\/experiment-record-anatomy-red-black\.svg$/, `${locale} Lab 003 visual asset is missing`);
+    assert.notEqual((await visual.locator('.reader-visual-explanation li').textContent() || '').trim(), '', `${locale} Lab 003 visual has no text explanation`);
+    assert.notEqual((await visual.locator('.reader-inline-visual-boundary').innerText()).trim(), '', `${locale} Lab 003 visual has no evidence boundary`);
+
+    const related = page.locator('[data-reader-related-visuals]');
+    assert.equal(await related.isVisible(), true, `${locale} Lab 003 related visuals are not discoverable`);
+    assert.equal(await related.locator('.reader-related-visual-card').count(), 2, `${locale} Lab 003 related visual sequence changed`);
+    assert.notEqual((await related.locator('[data-reader-related-visuals-boundary]').textContent() || '').trim(), '', `${locale} Lab 003 related visuals have no evidence boundary`);
+    await noHorizontalOverflow(`${locale} Lab 003 Reader`);
+  }
+  console.log(`READER_VISUAL_SMOKE_OK locales=${locales.length} lab=003 mobile=390 no_horizontal_overflow=1`);
+} finally {
+  await browser.close();
+  await new Promise((resolve) => server.close(resolve));
+}

--- a/scripts/reader_visual_smoke.mjs
+++ b/scripts/reader_visual_smoke.mjs
@@ -22,6 +22,16 @@ const locales = [
   ['fr', 'FR', 'Lab 003 : Auditer une affirmation de fin', 'Garder un essai assez petit pour être vérifiable'],
 ];
 const documentLanguages = { zh: 'zh-CN', 'zh-tw': 'zh-TW' };
+const researchLocales = [
+  ['en', 'EN'],
+  ['zh', 'ZH'],
+  ['es', 'ES'],
+  ['ja', 'JA'],
+  ['ko', 'KO'],
+  ['de', 'DE'],
+  ['zh-tw', 'ZHTW'],
+  ['fr', 'FR'],
+];
 
 const build = spawnSync(python, ['-X', 'utf8', 'scripts/build_pages_artifact.py', '--output', artifact], {
   cwd: root,
@@ -87,7 +97,22 @@ try {
     assert.notEqual((await related.locator('[data-reader-related-visuals-boundary]').textContent() || '').trim(), '', `${locale} Lab 003 related visuals have no evidence boundary`);
     await noHorizontalOverflow(`${locale} Lab 003 Reader`);
   }
-  console.log(`READER_VISUAL_SMOKE_OK locales=${locales.length} lab=003 mobile=390 no_horizontal_overflow=1`);
+
+  for (const [locale, suffix] of researchLocales) {
+    await page.goto(`${origin}/site/reader.html?path=book%2Fchapters%2F15-research-track-${suffix}.md&lang=${locale}`, { waitUntil: 'networkidle' });
+    await page.locator('[data-reader-article][aria-busy="false"] h1').waitFor();
+    assert.notEqual((await page.locator('[data-reader-article] h1').innerText()).trim(), '', `${locale} Chapter 15 has no localized heading`);
+
+    const related = page.locator('[data-reader-related-visuals]');
+    assert.equal(await related.isVisible(), true, `${locale} Chapter 15 related visuals are not discoverable`);
+    assert.equal(await related.locator('.reader-related-visual-card').count(), 2, `${locale} Chapter 15 related visual sequence changed`);
+    const maturityCard = related.locator('img[src*="evidence-maturity-ladder-red-black.svg"]');
+    assert.equal(await maturityCard.count(), 1, `${locale} Chapter 15 is missing the evidence maturity ladder`);
+    assert.notEqual((await maturityCard.getAttribute('alt') || '').trim(), '', `${locale} evidence maturity ladder has no localized alternative text`);
+    assert.notEqual((await related.locator('[data-reader-related-visuals-boundary]').textContent() || '').trim(), '', `${locale} Chapter 15 related visuals have no evidence boundary`);
+    await noHorizontalOverflow(`${locale} Chapter 15 Reader`);
+  }
+  console.log(`READER_VISUAL_SMOKE_OK locales=${locales.length} lab=003 research_locales=${researchLocales.length} chapter=15 mobile=390 no_horizontal_overflow=1`);
 } finally {
   await browser.close();
   await new Promise((resolve) => server.close(resolve));

--- a/site/reader.js
+++ b/site/reader.js
@@ -711,6 +711,16 @@
       'zh-tw': { title: '從證據走到判斷，再決定是否停止', body: '把紀錄與主張對照；證據或權限不足時，選擇有界線的行動、降低主張強度，或停止。', next: '這份紀錄實際允許我做出多強的判斷？', boundary: '這張圖只依紀錄排列判斷；它不能補足缺少的來源、權限或觀察。' },
       fr: { title: 'Passer des preuves à la décision, puis s’arrêter', body: 'Comparez le relevé à l’affirmation ; choisissez une action délimitée, reclassez l’affirmation ou arrêtez-vous si la preuve ou l’autorisation manque.', next: 'Quelle est la décision la plus forte que ce relevé permet réellement ?', boundary: 'La carte ordonne les décisions à partir d’un relevé ; elle ne remplace ni une source, ni une autorisation, ni une observation manquante.' },
     },
+    'evidence-maturity-ladder-red-black.svg': {
+      en: { title: 'Name the evidence stage you actually have', body: 'Separate a designed contract from a rendered page, a learner run, transfer, and independent review.', next: 'Which stage does this record support, and what evidence is still missing?', boundary: 'The ladder is a disclosure aid, not a score; it does not prove that a learner understood, transferred, or independently reviewed the method.' },
+      zh: { title: '说清你实际拥有哪一阶段的证据', body: '把已设计的契约、已呈现的页面、学习者运行、迁移和独立复核分开。', next: '这份记录支持到哪一阶段？还缺什么证据？', boundary: '这张阶梯图用于披露边界，不是评分；它不能证明学习者理解、迁移或方法已经经过独立复核。' },
+      es: { title: 'Nombra la etapa de evidencia que realmente tienes', body: 'Separa el contrato diseñado, la página publicada, la ejecución de un aprendiz, la transferencia y la revisión independiente.', next: '¿Qué etapa respalda este registro y qué evidencia falta todavía?', boundary: 'La escalera sirve para declarar límites, no para puntuar; no demuestra que un aprendiz haya entendido, transferido o revisado el método de forma independiente.' },
+      ja: { title: '実際に持っている証拠の段階を示す', body: '設計済みの契約、表示されたページ、学習者の実行、転用、独立レビューを分けます。', next: 'この記録が支える段階はどこで、まだ何が足りないか？', boundary: 'このラダーは開示の補助であり、点数ではありません。学習者の理解、転用、独立レビューを証明するものでもありません。' },
+      ko: { title: '실제로 가진 증거 단계를 밝히기', body: '설계된 계약, 렌더링된 페이지, 학습자 실행, 전이와 독립 검토를 구분합니다.', next: '이 기록이 뒷받침하는 단계는 어디이며, 아직 어떤 증거가 부족한가?', boundary: '이 단계표는 공개 범위를 설명하는 도구이지 점수가 아닙니다. 학습자의 이해·전이·독립 검토를 증명하지 않습니다.' },
+      de: { title: 'Die tatsächlich belegte Stufe benennen', body: 'Trenne den entworfenen Vertrag, die dargestellte Seite, den Lernlauf, die Übertragung und die unabhängige Prüfung.', next: 'Welche Stufe trägt dieser Beleg, und welcher Nachweis fehlt noch?', boundary: 'Die Leiter dient der Offenlegung, nicht der Bewertung. Sie belegt weder Verständnis noch Übertragung oder unabhängige Prüfung.' },
+      'zh-tw': { title: '說清楚你實際擁有哪些階段的證據', body: '把已設計的契約、已呈現的頁面、學習者執行、遷移與獨立複核分開。', next: '這份紀錄支持到哪個階段？還缺少什麼證據？', boundary: '這張階梯圖用來揭露界線，不是評分；它不能證明學習者理解、遷移或方法已經獨立複核。' },
+      fr: { title: 'Nommer le niveau de preuve réellement disponible', body: 'Séparez le contrat conçu, la page rendue, l’essai d’un apprenant, le transfert et la revue indépendante.', next: 'Quel niveau ce relevé permet-il de soutenir, et quelle preuve manque encore ?', boundary: 'Cette échelle sert à expliciter les limites, pas à attribuer une note ; elle ne prouve ni la compréhension, ni le transfert, ni une revue indépendante.' },
+    },
     'failed-interaction-recovery-red-black.svg': {
       en: { title: 'Recover from the first mismatch', body: 'Preserve the inputs and trace, classify the first mismatch, change one condition, and keep the result bounded.', next: 'What failed first, and what single safe change can test that diagnosis?', boundary: 'The board orders a recovery attempt; it does not prove that a retry worked or that the original gap is closed.' },
       zh: { title: '从第一个不匹配处开始恢复', body: '保留输入和轨迹，分类第一个不匹配，只改变一个条件，并让结论保持有边界。', next: '最先失败的是什么？哪一个单一且安全的改变能检验判断？', boundary: '这张图安排一次恢复尝试；它不能证明重试成功，也不能证明原始缺口已经消失。' },
@@ -770,6 +780,7 @@
     { tokens: ['chapter-15-research-track', 'lab-008-research-question', 'lab-015-evidence-delivery'], visuals: [
       { path: 'assets/teaching/research-question-to-source-record-red-black.svg', step: 3 },
       { path: 'assets/teaching/evidence-to-decision-stop-map-red-black.svg', step: 3 },
+      { path: 'assets/teaching/evidence-maturity-ladder-red-black.svg', step: 3 },
     ] },
     { tokens: ['chapter-16-engineering-track', 'chapter-18-content-design-data-automation', 'chapter-19-evaluate-models-and-workflows'], visuals: [
       { path: 'assets/teaching/lifecycle-checkpoints.svg', step: 2 },


### PR DESCRIPTION
## Summary
- add localized reader visual coverage for Lab 003 and research pages
- expose evidence maturity and next reading moves in the Reader
- record browser smoke boundaries and add a dedicated Reader visual smoke test

## Verification
- `python -X utf8 scripts/validate_project.py`
- `npm test` (49 script tests passed)
- `npm run test:visuals` (8 locales, 20 boards, mobile and no-script fallback)
- `npm run test:reader-visuals` (8 locales, Lab 003, Chapter 15, mobile overflow)

This branch contains six small, reviewable commits and is based on the current upstream `main`.