### PR TITLE
i18n(ja): localize transfer and evidence headings

### DIFF
--- a/book/chapters/18-content-design-data-automation-JA.md
+++ b/book/chapters/18-content-design-data-automation-JA.md
@@ -114,7 +114,7 @@ timeout、retry、backoff、idempotency key; log、trace ID、error 分類;
 
 level は、低リスクのローカル読み取り、可逆な project work、承認と log を持つ制御済み外部接続、明示的許可・privacy/license review・preview・rollback・online verification を持つ本番書込み／公開の四つです。上位に移るには新しい理由、permission、risk、evidence、回復計画が必要です。
 
-## automation contract：action より先に data を定義する
+## 自動化契約：アクションより先にデータを定義する
 
 offline の「aggregate count から一ページ report を作る」例です。synthetic JSON を読み、使い捨て directory に書くだけで、network、login、send はしません。
 
@@ -144,7 +144,7 @@ exit code 0 が示すのは script が自身の定義で終了したことだけ
 
 A–D 表、最終 render、data dictionary、validation、無効入力への応答、log、permission、retry、sandbox 状態、公開がなかった証拠を残します。模擬書込み後 timeout なら trace を保存して部分状態を照会し、非冪等操作を繰り返しません。実際の最終形の証拠と独立 review までは `candidate / not_run` です。
 
-## 小実験：offline report flow と二つの failure
+## 小実験：オフラインのレポートフローと二つの失敗
 
 ### 準備
 

--- a/book/chapters/19-evaluate-models-and-workflows-JA.md
+++ b/book/chapters/19-evaluate-models-and-workflows-JA.md
@@ -203,7 +203,7 @@ B の `markdown-02` 実行中に、capacity error、permission block、input cha
 - schema check は fixture が正しい形かを確認するだけで、model が実行されたことや学習者が方法を習得したことを示さない。
 - 条件が変わったら新しい decision-card version を作るか、run を比較不能にする。古い結論をそのまま使い続けない。
 
-## Transfer exercise
+## 転移課題
 
 同じ記録形式を、research question、marketing experiment、team skill の選択に適用します。run ID、input hash、score、decision card を残します。どの metric が移植でき、リスクに合わせてどれを変える必要があるか、少なくとも一つの「移植できない結論」を書きます。
 
@@ -244,11 +244,11 @@ B の `markdown-02` 実行中に、capacity error、permission block、input cha
 
 maintenance owner は、公式 model page、task-set version、evaluation fixture、account scope、cost basis、runtime surface を、それらのいずれかが変わったとき、遅くとも 2026-11-09 までに再確認します。指定された run log、独立 review、comparability check、evidence package がそろって初めて、結果を `verified` とします。さらに operational、security、permission、rollback、user-acceptance check がそろって初めて `production-ready` です。
 
-## Evidence を越えない handoff の練習
+## 証拠を越えない引き継ぎの練習
 
 評価 run の後で [Lab 015：完了という一文ではなく、evidence を渡す](../labs/lab-015-evidence-delivery-JA.md) を使います。Lab 003 は独立した claim adjudication を担当し、Lab 015 はその結果を使って、添付 evidence を越えない簡潔な handoff を作ります。
 
-## 5分比較カード：model の IQ ではなく、一つの instruction を試す
+## 5分比較カード：モデルの IQ ではなく、一つの指示を試す
 
 account 接続なしで、一つの model、offline の text、短時間で実行できます。短い公開済みまたは架空の status note を選びます。text、model、surface、time limit、reviewer を固定し、変えるのは instruction だけにします。
 

--- a/book/chapters/20-personal-codex-work-system-JA.md
+++ b/book/chapters/20-personal-codex-work-system-JA.md
@@ -112,7 +112,7 @@ Items to triage:
 3. 各 path を二回ずつ実行します。各 run の前に同じ input と temporary-copy baseline を復元します。`run-id` は `20-personal-system-triage-v1-A-01`、`A-02`、`B-01`、`B-02` を使います。
 4. 接続、write、公開、secret の読み取りはしません。task がそれを必要とするなら run を `blocked` とし、simulation から usability を推測しません。
 
-### Evidence gate
+### 証拠ゲート
 
 run ごとに一つの record を保存します。
 
@@ -165,7 +165,7 @@ project map に、意図的に stale な command と古い directory を一つ�
 - 独立した再現、failure set、transfer evidence がなければ、Skill は `candidate` のままです。
 - 設定された product feature、覚えている conversation、成功した build だけでは、現在の runtime behavior、team impact、deployment、user acceptance を証明できません。
 
-## Transfer task
+## 転移課題
 
 安定した個人 workflow を別の member に渡します。二人目は project map、task protocol、evidence index だけを使い、口頭補足なしで破棄可能な copy 上で作業します。input hash、run log、diff、acceptance result、missing-evidence list を保存します。書かれていなかった暗黙知を記録し、どの asset を修正するか決めます。
 

--- a/book/chapters/21-team-capability-system-JA.md
+++ b/book/chapters/21-team-capability-system-JA.md
@@ -110,7 +110,7 @@ external service への接続、account authorization、message の送信、cust
 3. B は読んだもの、実行した action、停止した箇所、output diff、validation、permission の判断、暗黙知の gap を記録します。
 4. A は一層だけを修正し、version を `0.1.1` に上げ、変更理由を記録します。B は `B-02` として再実行します。
 
-### Evidence gate
+### 証拠ゲート
 
 evidence package には次を含めます。
 
@@ -158,7 +158,7 @@ gap を shared language、method、evidence、governance のどれに分類し�
 - release、permission change、secret handling には別の approval が必要です。実験は自動的に権限を与えません。
 - configured capability、成功した build、宣言した team package だけでは runtime behavior、team outcome、deployment、user acceptance を証明できません。
 
-## Transfer task
+## 転移課題
 
 一つの capability package を personal project から organizational project へ移します。name、license、branding、data scope、permission、owner、reviewer、release target、rollback を再確認します。移植後も残る assumption と、捨てるべき assumption を一つずつ書きます。名前が似ているという理由だけで approve しません。
 

--- a/book/chapters/22-continuous-update-and-future-proofing-JA.md
+++ b/book/chapters/22-continuous-update-and-future-proofing-JA.md
@@ -122,7 +122,7 @@ maintainer が「action X の公開説明が変わった」という notice を�
 
 decision card には `decision_owner`、`delivery_target`（この演習では temporary copy のみ）、`reviewer`、`rollback_target` を含めます。どれかが欠けたら `blocked` のままです。紙上の status 変更は、update loop 完了の証拠ではありません。
 
-### Evidence gate
+### 証拠ゲート
 
 evidence package には claim YAML、source snapshot または unavailable-source record、access date と scope、impact matrix、before/after hash、diff、check output、status transition の理由、unverified-items list、owner、next review、rollback instructions を含めます。必須十項目は次のとおりです：claim、source、scope、owner、`next_review`、baseline hash、after hash/diff、impact matrix、validation log、unverified list。どれか一つ欠ければ update loop は完了していません。
 
@@ -145,7 +145,7 @@ task set、scope、source、permission、migration note を更新せず、新し
 - `claim_status: current` は宣言された scope 内に current source があるという意味だけです。chapter、Skill、experiment、deployment、runtime が `verified` という意味ではありません。
 - successful build、準備済み package、文書化された migration は、実際の evidence がない限り production behavior や team effect の証拠ではありません。
 
-## Transfer task
+## 転移課題
 
 実在するが redacted な外部 Skill candidate を一つ選びます。claim record と impact matrix を使い、unreviewed から `blocked` または adaptation candidate へ移します。license、dependency、trigger、permission、risk、owner、evaluation evidence の何が不足しているかを書きます。名前が適切に見えるだけで approve しません。
 
@@ -189,7 +189,7 @@ lifecycle、impact matrix、rollback、evidence gate は project methodology で
 
 この project の update process は [`docs/governance/content-lifecycle.md`](../evidence-library-JA.md#method-and-status) にも記録されています。この章は `candidate`、演習は `draft / not_run` のままです。上の `claim_status` はどちらの結論も変更しません。
 
-## 公開前の最小 update card
+## 公開前の最小更新カード
 
 新しい名前や page screenshot を見つけても、書籍全体を一括置換しません。rollback できる card で変更を狭め、なぜその範囲だけを変えるのか、まだ何を言えないのかを次の maintainer に渡します。
 

--- a/scripts/validate_learning_contract.py
+++ b/scripts/validate_learning_contract.py
@@ -121,7 +121,7 @@ CHAPTER_CONTRACT = {
     "transfer": re.compile(
         r"(?m)^(?:##|###)\s+(?:迁移|遷移|迁移练习|遷移練習|遷移任務|Transfer|Transfer task|"
         r"Transfer exercise|Transferaufgabe|Tarea de transferencia|"
-        r"Transferencia|Übertragung|迁移任务|移行|移行タスク|転移タスク|別の分野へ移す|移行と振り返り|応用課題|応用|전환|전이 과제|응용 과제|Transfert|Exercice de transfert)(?:\s+.*)?$",
+        r"Transferencia|Übertragung|迁移任务|移行|移行タスク|転移タスク|転移課題|別の分野へ移す|移行と振り返り|応用課題|応用|전환|전이 과제|응용 과제|Transfert|Exercice de transfert)(?:\s+.*)?$",
         re.IGNORECASE,
     ),
     "acceptance": re.compile(


### PR DESCRIPTION
## Scope
Localize the remaining Japanese reader-facing headings for automation, transfer, evidence, and comparison sections in Chapters 18–22.

## Files
- book/chapters/18-content-design-data-automation-JA.md
- book/chapters/19-evaluate-models-and-workflows-JA.md
- book/chapters/20-personal-codex-work-system-JA.md
- book/chapters/21-team-capability-system-JA.md
- book/chapters/22-continuous-update-and-future-proofing-JA.md
- scripts/validate_learning_contract.py (recognize the localized heading)

## Verification
The full LF integration snapshot passes the repository test runner and localization/navigation/learning-contract validators. This PR changes headings only; it does not claim Japanese content is independently reviewed or learner-validated.