### PR TITLE
fix(fr): correct Agent title grammar

### DIFF
--- a/site/content-catalog.json
+++ b/site/content-catalog.json
@@ -45,7 +45,7 @@
         "ko": "컨텍스트, 권한, Agent 경계",
         "de": "Kontext, Berechtigungen und Agent-Grenzen",
         "zh-tw": "上下文、權限與 Agent 邊界",
-        "fr": "Contexte, autorisations et limites Agent"
+        "fr": "Contexte, autorisations et limites de l’Agent"
       }
     },
     "chapter-05": {
@@ -141,7 +141,7 @@
         "ko": "Agent 루프, 상태, 중지 조건",
         "de": "Die Agent-Schleife, Zustand und Stoppbedingungen",
         "zh-tw": "Agent 的循環、狀態與停止條件",
-        "fr": "Conditions de boucle, d'état et d'arrêt du Agent"
+        "fr": "Conditions de boucle, d'état et d'arrêt de l’Agent"
       }
     },
     "chapter-13": {

--- a/site/learning-path-data.js
+++ b/site/learning-path-data.js
@@ -623,7 +623,7 @@ window.CODEX_LEARNING_PATH = {
             "ko": "컨텍스트, 권한, Agent 경계",
             "de": "Kontext, Berechtigungen und Agent-Grenzen",
             "zh-tw": "上下文、權限與 Agent 邊界",
-            "fr": "Contexte, autorisations et limites Agent"
+            "fr": "Contexte, autorisations et limites de l’Agent"
           },
           "href": "../book/chapters/04-context-permissions-and-agent-EN.md",
           "relation": "primary"
@@ -2148,7 +2148,7 @@ window.CODEX_LEARNING_PATH = {
             "ko": "Agent 루프, 상태, 중지 조건",
             "de": "Die Agent-Schleife, Zustand und Stoppbedingungen",
             "zh-tw": "Agent 的循環、狀態與停止條件",
-            "fr": "Conditions de boucle, d'état et d'arrêt du Agent"
+            "fr": "Conditions de boucle, d'état et d'arrêt de l’Agent"
           },
           "href": "../book/chapters/12-agent-loop-and-stop-EN.md",
           "relation": "primary"
@@ -2457,7 +2457,7 @@ window.CODEX_LEARNING_PATH = {
             "ko": "Agent 루프, 상태, 중지 조건",
             "de": "Die Agent-Schleife, Zustand und Stoppbedingungen",
             "zh-tw": "Agent 的循環、狀態與停止條件",
-            "fr": "Conditions de boucle, d'état et d'arrêt du Agent"
+            "fr": "Conditions de boucle, d'état et d'arrêt de l’Agent"
           },
           "href": "../book/chapters/12-agent-loop-and-stop-EN.md",
           "relation": "primary"


### PR DESCRIPTION
## Summary

- Correct two French Agent title strings in the canonical site content catalog.
- Regenerate site/learning-path-data.js from site/content-catalog.json; no generated file was edited by hand.
- This PR contains only the two title corrections and their generated projections.

## Validation

- build_learning_path_site.py --check
- validate_site_i18n.py (677/677)
- validate_site_accessibility.py
- test_site_accessibility.py
- validate_localization.py
- validate_content_completeness.py
- validate_project_structure.py
- validate_learning_contract.py --canonical-en
- check_local_links.py

All checks passed. The project remains candidate and French content remains in-progress where declared. AI assistance was used for the initial audit, followed by source review, regeneration, and validation.