### PR TITLE
test(fr): match formal fundamentals boundary wording

### DIFF
--- a/scripts/validate_llm_fundamentals_boundaries.py
+++ b/scripts/validate_llm_fundamentals_boundaries.py
@@ -85,7 +85,7 @@ ACCURACY_MARKERS = {
     "KO": ("유한한 context window", "cutoff만으로 판단하지 말고"),
     "DE": ("endliches Kontextfenster", "ein Cutoff allein entscheidet die Frage nicht"),
     "ZHTW": ("有限的上下文視窗", "不能只憑截止日期下結論"),
-    "FR": ("fenêtre de contexte finie", "plutôt que de se fier uniquement à la date de coupure"),
+    "FR": ("fenêtre de contexte finie", "plutôt que de vous fier uniquement à la date de coupure"),
 }
 
 MICRO_EXPERIMENT_MARKERS = {


### PR DESCRIPTION
Fix the French fundamentals boundary validator to match the formal wording already present in the localized guide.

Validation:
- `python scripts/validate_llm_fundamentals_boundaries.py`
- `python scripts/validate_project.py`
- `python scripts/validate_project_structure.py`
- `python scripts/validate_content_completeness.py`
- `python scripts/validate_learning_contract.py --canonical-en`
- `python scripts/check_local_links.py`
- Python tests: 5 passed

Scope: one validator marker only. No learner, product, translation-completeness, or production-readiness claim.

AI assistance: generated and checked with AI assistance; the repository maintainer should review the diff and checks.