### PR TITLE
ci: run CodeQL for every pull request

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,9 @@ name: Prysai LLM Playbook CodeQL
 
 on:
   pull_request:
-    paths:
-      - "**.py"
-      - "**.js"
-      - "**.mjs"
-      - "**.ts"
-      - "**.tsx"
-      - ".github/workflows/codeql.yml"
+    # The repository Ruleset requires a CodeQL result for every PR. Do not
+    # path-filter this event: documentation-only PRs still need a completed
+    # result rather than a permanently pending required check.
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Tracking and summary

- Related issue or discussion (or rationale for none): No separate issue; this PR addresses the live required-check deadlock reported by the repository Ruleset.
- Problem: The CodeQL workflow filtered pull-request events to code-file paths, while the active Ruleset requires a CodeQL result for every pull request. Documentation-only PRs therefore stayed pending forever.
- Intended outcome: Every pull request receives completed CodeQL matrix checks, including documentation-only and configuration-only changes.
- Scope and intentionally out of scope: Change only the pull_request trigger. Do not change Ruleset requirements, signature enforcement, approvals, or auto-merge eligibility.

## Implementation or editorial approach

- Approach: Remove the pull_request.paths filter while retaining the existing path filter for pushes to main.
- Canonical source(s): .github/workflows/codeql.yml
- Generated outputs or migration impact (or not applicable): Not applicable. Existing open PRs must receive a new event/check run before their CodeQL status can be re-evaluated.

## Change class

- [ ] Small correction
- [ ] Content change
- [x] Contract change
- [x] Behavior change
- [ ] Release change
- [ ] Test material

## Contribution route and review request

- Route: [x] Standard review [ ] Fast material review [ ] Restricted evidence intake / do not merge public data
- Receipt or protocol path (or not applicable): Not applicable
- Requested reviewer role: Repository maintainer and security-workflow reviewer

## Contribution declaration

- DCO: [x] I have read DCO.md, have the right to submit this work, and signed every commit.
- Project license boundary: [x] I accept CC BY 4.0 for project-owned content or Apache-2.0 for project-owned code/tooling, as applicable.

## Translation details

Not applicable.

## Source, authorship, and license

This is an original repository workflow correction. It adds no external code, images, or copied content. The GitHub Actions behavior is documented by the GitHub Actions and Rulesets documentation:
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets
No asset-register update is required.

## Safety and external effects

The change causes CodeQL CI to run for every pull request, increasing CI usage for documentation-only PRs. It does not add secrets, credentials, external publishing, deletion, or write permissions. The existing workflow permissions and pinned action references remain unchanged. Rollback is a one-commit revert.

## Security review

This changes a security-related workflow trigger and requires maintainer review. No new action, dependency, secret, permission, checkout behavior, or CodeQL query is introduced; the existing pinned CodeQL actions and security-events: write permission remain unchanged. The security concern addressed is the mismatch between a required CodeQL status and a path-filtered pull-request event.

## AI assistance

- AI assistance used: [x] Yes — an AI-assisted diagnosis identified the trigger/Ruleset mismatch; the repository owner reviewed the scope, local validation results, and final patch.

## Validation and evidence

- python scripts/validate_repository_security.py -> REPOSITORY_SECURITY_POLICY_OK workflows=9 candidate_files=1618 host_ruleset=active
- python scripts/test_validate_repository_security.py -> REPOSITORY_SECURITY_POLICY_TESTS_OK fixtures=56
- git diff --check -> passed
- Commit: 74610f94247b05f970b330892702cc73c2f81ec9
- Local signature check: git show --show-signature reports a good ED25519 signature.
- The GitHub Actions checks for this PR are the source of truth for hosted validation.

## Unverified and out of scope

The hosted CodeQL matrix has not yet run for this new PR at submission time. Existing open PRs will need their checks refreshed after this fix reaches main; this PR does not rewrite historical commits or fabricate DCO/signature evidence. End-to-end native auto-merge behavior remains out of scope for this workflow-only change.

## Status claim

Candidate: the patch and local repository-policy checks pass; hosted CI and maintainer review are still required. This PR does not claim production readiness.

## Checklist

- [x] I changed the canonical source, not only a generated projection.
- [x] I linked the issue/design context or explained why it is not applicable.
- [x] I kept this PR to one logical change.
- [x] I recorded volatile facts with URL, access date, scope, owner, and next review.
- [x] I registered external assets and license decisions before adaptation.
- [x] I did not commit secrets, credentials, private data, or machine-local configuration.
- [x] I ran the relevant validators and stated what they do not prove.
- [x] I kept translation, runtime, review, and maturity claims honest.
- [x] I documented rollback/recovery for contract, behavior, or release changes, or marked it not applicable.
- [x] I added a valid Signed-off-by line to every commit; the PR check is the source of truth.
- [x] If this is test material, it is original fictional material with no raw learner work, raw model output, identifiers, consent records, or outcome claim.