### PR TITLE
ci: isolate post-merge publication concurrency

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -71,6 +71,21 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Package the public Docs verifier
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/docs-verifier"
+          cp scripts/check_deployed_site.py "$RUNNER_TEMP/docs-verifier/check_deployed_site.py"
+
+      - name: Upload the public Docs verifier
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-verifier-${{ github.sha }}
+          path: ${{ runner.temp }}/docs-verifier
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Archive Pages deployment artifact
         if: ${{ (inputs.deploy || github.event_name == 'push') && github.ref == 'refs/heads/main' }}
         shell: bash
@@ -186,6 +201,13 @@ jobs:
           path: _site
           github-token: ${{ github.token }}
 
+      - name: Download the trusted public verifier
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docs-verifier-${{ github.sha }}
+          path: docs-verifier
+          github-token: ${{ github.token }}
+
       - name: Configure the restricted deployment key
         env:
           DOCS_DEPLOY_SSH_KEY: ${{ secrets.DOCS_DEPLOY_SSH_KEY }}
@@ -206,41 +228,9 @@ jobs:
           -o UserKnownHostsFile="$HOME/.ssh/known_hosts"
           prysai-docs-deploy@docs.prysai.com
 
-  verify-docs-prysai-public:
-    needs: docs-prysai-deploy
-    if: ${{ needs.docs-prysai-deploy.result == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    permissions:
-      actions: read
-      contents: read
-    # Serialize verification with Docs publication. Otherwise a newer Docs
-    # publish could change the public bytes while this job is still comparing
-    # the previous run's artifact, producing a false failure.
-    concurrency:
-      group: docs-prysai-production
-      cancel-in-progress: false
-    steps:
-      - name: Check out deployment verifier
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Download the validated Pages artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pages-candidate-${{ github.sha }}
-          path: _site
-          github-token: ${{ github.token }}
-
-      - name: Set up Python for the public verifier
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-
       - name: Verify the public Docs site matches this artifact
         run: >-
-          python scripts/check_deployed_site.py
+          python docs-verifier/check_deployed_site.py
           --artifact _site
           --base-url https://docs.prysai.com/llm-playbook/
           --attempts 18

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,21 +3,6 @@ name: Build and publish Prysai LLM Playbook site
 on:
   push:
     branches: [main]
-    paths:
-      - "book/**"
-      - "docs/**"
-      - "site/**"
-      - "skills/**"
-      - "assets/**"
-      - "examples/**"
-      - "evals/**"
-      - "AGENTS.md"
-      - "CONTEXT.md"
-      - "scripts/build_*.py"
-      - "scripts/check_deployed_site.py"
-      - "scripts/validate_*.py"
-      - "README*.md"
-      - ".github/workflows/pages.yml"
   workflow_dispatch:
     inputs:
       deploy:
@@ -29,17 +14,19 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
+# Keep concurrency at the publication boundary. The Docs job is protected by
+# a required environment review and must not hold the build, Pages, or
+# Hugging Face jobs in a workflow-wide queue.
 
 jobs:
   build:
-    # Builds the bounded site artifact on every content push; deploys to
-    # GitHub Pages when Pages is enabled for the repository (public
-    # repositories on the free plan support it). The build job stays
-    # green even when Pages is not yet enabled, so deployment is opt-in.
+    # Build the bounded site artifact on every push to main. Downstream
+    # publication jobs consume this exact candidate; a protected Docs review
+    # must not hold the build or the other publication surfaces.
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages-build-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -58,49 +45,8 @@ jobs:
       - name: Build the bounded Pages artifact
         run: python scripts/build_pages_artifact.py --output _site
 
-      - name: Detect Hugging Face publication configuration
-        id: huggingface-sync
-        if: ${{ (inputs.deploy || github.event_name == 'push') && github.ref == 'refs/heads/main' }}
-        shell: bash
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          if [[ -n "$HF_TOKEN" ]]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-            echo "huggingface_sync=enabled" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "huggingface_sync=not_configured" >> "$GITHUB_STEP_SUMMARY"
-            echo "Add a fine-grained Hugging Face write token as the HF_TOKEN repository secret to enable publication." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Set up uv for Hugging Face publication
-        if: steps.huggingface-sync.outputs.enabled == 'true'
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          # This workflow has no uv lockfile or requirements file to cache.
-          enable-cache: false
-
-      - name: Sync the built site to Hugging Face
-        if: steps.huggingface-sync.outputs.enabled == 'true'
-        shell: bash
-        env:
-          HF_REPO_ID: Prysai/Prysai-LLM-Playbook
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          REPO_TYPE: space
-          SPACE_SDK: static
-          SUBDIRECTORY: _site
-        run: |
-          set -euo pipefail
-          test -n "$HF_TOKEN"
-          test -d "$SUBDIRECTORY"
-          uvx hf repo create "$HF_REPO_ID" --repo-type "$REPO_TYPE" --exist-ok --space-sdk "$SPACE_SDK"
-          uvx hf upload "$HF_REPO_ID" "$SUBDIRECTORY" \
-            --repo-type "$REPO_TYPE" \
-            --exclude='.git*' \
-            --exclude='.github*' \
-            --delete='*' \
-            --commit-message='Sync from GitHub via Pages workflow'
+      - name: Record candidate artifact
+        run: echo "candidate_artifact=pages-candidate-${GITHUB_SHA}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Record deployment boundary
         shell: bash
@@ -139,9 +85,74 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  sync-huggingface:
+    needs: build
+    if: ${{ (github.event_name == 'push' || inputs.deploy) && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+    concurrency:
+      group: huggingface-publication
+      cancel-in-progress: false
+    steps:
+      - name: Detect Hugging Face publication configuration
+        id: huggingface-sync
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [[ -n "$HF_TOKEN" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "huggingface_sync=enabled" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "huggingface_sync=not_configured" >> "$GITHUB_STEP_SUMMARY"
+            echo "Add a fine-grained Hugging Face write token as the HF_TOKEN repository secret to enable publication." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Download the validated Pages artifact
+        if: steps.huggingface-sync.outputs.enabled == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pages-candidate-${{ github.sha }}
+          path: _site
+          github-token: ${{ github.token }}
+
+      - name: Set up uv for Hugging Face publication
+        if: steps.huggingface-sync.outputs.enabled == 'true'
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # This workflow has no uv lockfile or requirements file to cache.
+          enable-cache: false
+
+      - name: Sync the built site to Hugging Face
+        if: steps.huggingface-sync.outputs.enabled == 'true'
+        shell: bash
+        env:
+          HF_REPO_ID: Prysai/Prysai-LLM-Playbook
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          REPO_TYPE: space
+          SPACE_SDK: static
+          SUBDIRECTORY: _site
+        run: |
+          set -euo pipefail
+          test -n "$HF_TOKEN"
+          test -d "$SUBDIRECTORY"
+          uvx hf repo create "$HF_REPO_ID" --repo-type "$REPO_TYPE" --exist-ok --space-sdk "$SPACE_SDK"
+          uvx hf upload "$HF_REPO_ID" "$SUBDIRECTORY" \
+            --repo-type "$REPO_TYPE" \
+            --exclude='.git*' \
+            --exclude='.github*' \
+            --delete='*' \
+            --commit-message='Sync from GitHub via Pages workflow'
+
   deploy:
     needs: build
     if: ${{ (inputs.deploy || github.event_name == 'push') && github.ref == 'refs/heads/main' }}
+    concurrency:
+      group: github-pages-deployment
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write
@@ -203,6 +214,12 @@ jobs:
     permissions:
       actions: read
       contents: read
+    # Serialize verification with Docs publication. Otherwise a newer Docs
+    # publish could change the public bytes while this job is still comparing
+    # the previous run's artifact, producing a false failure.
+    concurrency:
+      group: docs-prysai-production
+      cancel-in-progress: false
     steps:
       - name: Check out deployment verifier
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/adr/0048-post-publish-public-artifact-check.md
+++ b/docs/adr/0048-post-publish-public-artifact-check.md
@@ -16,15 +16,17 @@ can make a newly published language route undiscoverable.
 
 ## Decision
 
-After the atomic Docs publish, the workflow runs
-`scripts/check_deployed_site.py` against the public
+After the atomic Docs publish, the protected deployment job runs a trusted
+copy of `scripts/check_deployed_site.py` against the public
 `https://docs.prysai.com/llm-playbook/` base URL. The check compares the
 generated root, discovery files, all static locale entry pages, and every
-versioned Reader/homepage asset with the downloaded artifact. It runs in a
-separate, secret-free verification job after the publish job. A bounded retry
-window and build-SHA query parameter reduce false negatives from normal
-propagation and cache delay. A persistent HTTP error or byte mismatch fails
-the deployment workflow.
+versioned Reader/homepage asset with the downloaded artifact. The verifier is
+packaged by the read-only build job as a separate, non-public artifact; the
+secret-bearing deployment job does not check out repository source or rebuild
+the site. Running publish and verification sequentially in one protected job
+avoids cross-workflow concurrency races. A bounded retry window and build-SHA
+query parameter reduce false negatives from normal propagation and cache
+delay. A persistent HTTP error or byte mismatch fails the deployment workflow.
 
 The check reports deployment-integrity evidence only. It does not establish
 translation quality, learning outcomes, uptime, or release readiness.

--- a/docs/adr/0051-isolate-post-merge-publication-concurrency.md
+++ b/docs/adr/0051-isolate-post-merge-publication-concurrency.md
@@ -84,3 +84,11 @@ the one validated Pages candidate artifact instead.
 - [GitHub Actions concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)
 - [GitHub Pages custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
 - [`workflow_run` security boundary](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run)
+
+## Source record
+
+| Source | Accessed | Scope | Owner | Next review |
+| --- | --- | --- | --- | --- |
+| [GitHub Actions concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) | 2026-08-31 | Job and workflow concurrency groups, pending-run behavior, and cancellation semantics | governance-maintainer | 2026-09-30 |
+| [GitHub Pages custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-actions) | 2026-08-31 | Pages artifact deployment workflow and deployment action boundary | governance-maintainer | 2026-09-30 |
+| [`workflow_run` security boundary](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run) | 2026-08-31 | Trusted workflow event and default-branch execution considerations | governance-maintainer | 2026-09-30 |

--- a/docs/adr/0051-isolate-post-merge-publication-concurrency.md
+++ b/docs/adr/0051-isolate-post-merge-publication-concurrency.md
@@ -1,0 +1,83 @@
+# ADR-0051: Isolate post-merge publication concurrency
+
+## Status
+
+Accepted. This decision changes workflow scheduling only; it does not remove
+the protected Docs environment review or promote any content maturity status.
+
+## Date
+
+2026-08-31
+
+## Context
+
+The Pages workflow runs after a push to `main`, which includes a pull request
+merge. One workflow run builds a bounded artifact and publishes it to the
+GitHub Pages environment, the optional Hugging Face Space, and the separate
+`docs.prysai.com` host. The Docs host is protected by the
+`docs-prysai-production` environment and a required `uuzzrm` reviewer.
+
+The workflow previously used one workflow-wide `pages` concurrency group.
+When the Docs job waited for that environment review, the waiting run held the
+same group as the build and Pages/Hugging Face work. Later merges therefore
+queued behind an external approval even when the independent publication jobs
+could have completed.
+
+## Decision
+
+1. Run the workflow on every push to `main`, without a content-path filter, so
+   a merged pull request always creates a fresh candidate and publication
+   attempt. `workflow_dispatch` remains available for an explicit retry.
+2. Keep the build concurrency group separate and cancel superseded builds for
+   the same ref. The newest main candidate is the only build that needs to
+   continue.
+3. Download the validated `pages-candidate-${{ github.sha }}` artifact in a
+   dedicated Hugging Face job. Its token is limited to `actions: read`, and its
+   concurrency group is independent of Pages and Docs.
+4. Keep GitHub Pages in its own serialized deployment group. Keep Hugging Face
+   in its own serialized publication group so a provider upload is not
+   canceled mid-mutation. Keep both the Docs deployment and its public-byte
+   verifier in the protected `docs-prysai-production` group with the existing
+   reviewer and artifact-only secret boundary.
+5. Treat the GitHub repository UI as a direct view of `main`; it needs no
+   separate deployment job. `prysai.com` is a separately owned public host and
+   is not changed by this workflow.
+
+## Alternatives considered
+
+### Keep one workflow-wide group
+
+Rejected: an environment approval on one surface blocks unrelated publication
+jobs and makes every later merge appear stale.
+
+### Remove Docs environment protection
+
+Rejected: the required reviewer and branch policy are the host-side safety
+boundary for a secret-bearing external deployment.
+
+### Rebuild independently for each host
+
+Rejected: separate builds could publish different bytes. Every host consumes
+the one validated Pages candidate artifact instead.
+
+## Consequences
+
+- Every merge to `main` triggers a workflow run, including merges that do not
+  change reader-facing files.
+- Pages and Hugging Face can finish while Docs waits for its required review.
+- A newer build supersedes an older in-progress build; each external
+  publication group remains serialized so an approved transfer or provider
+  upload is not interrupted mid-mutation. Docs verification is serialized with
+  the publish step to avoid comparing an old artifact after a newer one is live.
+- A successful workflow still does not prove that the external host is serving
+  the candidate until the post-publish public verifier succeeds.
+
+## Evidence boundary
+
+- [`.github/workflows/pages.yml`](../../.github/workflows/pages.yml)
+- [`docs/governance/repository-security-policy.yaml`](../governance/repository-security-policy.yaml)
+- [`docs/adr/0045-deploy-only-validated-pages-artifact.md`](0045-deploy-only-validated-pages-artifact.md)
+- [`docs/adr/0048-post-publish-public-artifact-check.md`](0048-post-publish-public-artifact-check.md)
+- [GitHub Actions concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)
+- [GitHub Pages custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)
+- [`workflow_run` security boundary](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run)

--- a/docs/adr/0051-isolate-post-merge-publication-concurrency.md
+++ b/docs/adr/0051-isolate-post-merge-publication-concurrency.md
@@ -36,9 +36,11 @@ could have completed.
    concurrency group is independent of Pages and Docs.
 4. Keep GitHub Pages in its own serialized deployment group. Keep Hugging Face
    in its own serialized publication group so a provider upload is not
-   canceled mid-mutation. Keep both the Docs deployment and its public-byte
-   verifier in the protected `docs-prysai-production` group with the existing
-   reviewer and artifact-only secret boundary.
+   canceled mid-mutation. Keep Docs publication and its public-byte verifier
+   in one protected `docs-prysai-production` job. The build job supplies the
+   verifier as a separate, non-public artifact, so the secret-bearing job does
+   not check out or execute repository source while it publishes and then
+   verifies the same Pages candidate.
 5. Treat the GitHub repository UI as a direct view of `main`; it needs no
    separate deployment job. `prysai.com` is a separately owned public host and
    is not changed by this workflow.
@@ -67,8 +69,9 @@ the one validated Pages candidate artifact instead.
 - Pages and Hugging Face can finish while Docs waits for its required review.
 - A newer build supersedes an older in-progress build; each external
   publication group remains serialized so an approved transfer or provider
-  upload is not interrupted mid-mutation. Docs verification is serialized with
-  the publish step to avoid comparing an old artifact after a newer one is live.
+  upload is not interrupted mid-mutation. Docs verification runs immediately
+  after its publish step in the same protected job, avoiding cross-workflow
+  ordering races between a verifier and a newer publication.
 - A successful workflow still does not prove that the external host is serving
   the candidate until the post-publish public verifier succeeds.
 

--- a/docs/adr/0051-isolate-post-merge-publication-concurrency.md
+++ b/docs/adr/0051-isolate-post-merge-publication-concurrency.md
@@ -90,5 +90,5 @@ the one validated Pages candidate artifact instead.
 | Source | Accessed | Scope | Owner | Next review |
 | --- | --- | --- | --- | --- |
 | [GitHub Actions concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) | 2026-08-31 | Job and workflow concurrency groups, pending-run behavior, and cancellation semantics | governance-maintainer | 2026-09-30 |
-| [GitHub Pages custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-actions) | 2026-08-31 | Pages artifact deployment workflow and deployment action boundary | governance-maintainer | 2026-09-30 |
+| [GitHub Pages custom workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages) | 2026-08-31 | Pages artifact deployment workflow and deployment action boundary | governance-maintainer | 2026-09-30 |
 | [`workflow_run` security boundary](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run) | 2026-08-31 | Trusted workflow event and default-branch execution considerations | governance-maintainer | 2026-09-30 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,3 +66,4 @@ Current entry points:
 - [ADR-0048: verify the public Docs host after artifact publication](0048-post-publish-public-artifact-check.md)
 - [ADR-0049: keep maintainer-only release controls out of public artifacts](0049-maintainer-only-release-controls.md)
 - [ADR-0050: constrain maintainer documentation auto-merge](0050-constrained-maintainer-documentation-auto-merge.md)
+- [ADR-0051: isolate post-merge publication concurrency](0051-isolate-post-merge-publication-concurrency.md)

--- a/docs/governance/repository-security-policy.yaml
+++ b/docs/governance/repository-security-policy.yaml
@@ -67,6 +67,7 @@
       "pinned binary-only Python validation dependency",
       "same-origin static-site Content-Security-Policy meta contract",
       "secret-bearing Docs deployment consumes only the validated Pages artifact",
+      "post-merge Pages, Docs, and Hugging Face publication jobs keep independent concurrency boundaries",
       "policy fixture tests, including synthetic-path false-positive boundaries",
       "read-only pull-request contract headings, exact-head check, and per-commit DCO sign-offs",
       "maintainer documentation auto-merge workflow boundary and permission exception"

--- a/scripts/test_validate_repository_security.py
+++ b/scripts/test_validate_repository_security.py
@@ -168,6 +168,12 @@ jobs:
           name: pages-candidate-${{ github.sha }}
           path: _site
           github-token: ${{ github.token }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: docs-verifier-${{ github.sha }}
+          path: docs-verifier
+          github-token: ${{ github.token }}
+      - run: python docs-verifier/check_deployed_site.py --artifact _site
   another-job:
     runs-on: ubuntu-latest
 """

--- a/scripts/test_validate_repository_security.py
+++ b/scripts/test_validate_repository_security.py
@@ -189,6 +189,31 @@ jobs:
         )
         fixtures += 1
 
+        pages_workflow = policy.PAGES_WORKFLOW.read_text(encoding="utf-8")
+        require(
+            not policy.validate_pages_post_merge_orchestration(pages_workflow, "pages.yml"),
+            "Pages workflow did not retain the post-merge publication boundary",
+        )
+        fixtures += 1
+        workflow_wide_concurrency = pages_workflow.replace(
+            "# Keep concurrency at the publication boundary. The Docs job is protected by\n# a required environment review and must not hold the build, Pages, or\n# Hugging Face jobs in a workflow-wide queue.\n",
+            "concurrency:\n  group: pages\n  cancel-in-progress: false\n",
+        )
+        require(
+            any("workflow-wide concurrency" in error for error in policy.validate_pages_post_merge_orchestration(workflow_wide_concurrency, "pages.yml")),
+            "Pages workflow with a workflow-wide concurrency group was accepted",
+        )
+        fixtures += 1
+        filtered_main_push = pages_workflow.replace(
+            "  push:\n    branches: [main]\n",
+            "  push:\n    branches: [main]\n    paths:\n      - \"site/**\"\n",
+        )
+        require(
+            any("must not filter paths" in error for error in policy.validate_pages_post_merge_orchestration(filtered_main_push, "pages.yml")),
+            "Pages workflow with a post-merge path filter was accepted",
+        )
+        fixtures += 1
+
         secure_codeql = """on:
   pull_request:
 permissions:

--- a/scripts/validate_repository_security.py
+++ b/scripts/validate_repository_security.py
@@ -74,6 +74,9 @@ DOCS_DEPLOY_REQUIRED_FRAGMENTS = (
     "name: pages-candidate-${{ github.sha }}",
     "path: _site",
     "github-token: ${{ github.token }}",
+    "name: docs-verifier-${{ github.sha }}",
+    "path: docs-verifier",
+    "python docs-verifier/check_deployed_site.py",
 )
 DOCS_DEPLOY_ALLOWED_PERMISSIONS = {"actions": "read"}
 LEGACY_NODE20_ACTION_PINS = (
@@ -691,8 +694,8 @@ def validate_pages_post_merge_orchestration(text: str, label: str) -> list[str]:
         if re.search(r"(?m)^    paths(?:-ignore)?:\s*$", push_body):
             errors.append(f"{label}: Pages push trigger must not filter paths after a merge")
 
-    if text.count("group: docs-prysai-production") < 2:
-        errors.append(f"{label}: Docs publication and public verification must share their serialized host group")
+    if text.count("group: docs-prysai-production") < 1:
+        errors.append(f"{label}: Docs publication must use the protected serialized host group")
     return errors
 
 

--- a/scripts/validate_repository_security.py
+++ b/scripts/validate_repository_security.py
@@ -87,6 +87,14 @@ PAGES_CANDIDATE_ARTIFACT_REQUIRED = (
     "path: _site",
     "include-hidden-files: true",
 )
+PAGES_POST_MERGE_REQUIRED_FRAGMENTS = (
+    "workflow_dispatch:",
+    "sync-huggingface:",
+    "group: pages-build-${{ github.ref }}",
+    "group: huggingface-publication",
+    "group: github-pages-deployment",
+    "group: docs-prysai-production",
+)
 DOCS_DEPLOY_FORBIDDEN_FRAGMENTS = (
     "actions/checkout@",
     "actions/setup-python@",
@@ -660,6 +668,34 @@ def validate_pages_candidate_artifact(text: str, label: str) -> list[str]:
     return errors
 
 
+def validate_pages_post_merge_orchestration(text: str, label: str) -> list[str]:
+    """Keep every main push deployable without cross-surface queue blocking."""
+
+    errors = []
+    if re.search(r"(?m)^concurrency:\s*$", text):
+        errors.append(f"{label}: Pages workflow must not use workflow-wide concurrency")
+    for fragment in PAGES_POST_MERGE_REQUIRED_FRAGMENTS:
+        if fragment not in text:
+            errors.append(f"{label}: post-merge publication contract is missing: {fragment}")
+
+    push_match = re.search(
+        r"(?ms)^  push:\s*\n(?P<body>.*?)(?=^  workflow_dispatch:\s*$|^permissions:\s*$|\Z)",
+        text,
+    )
+    if not push_match:
+        errors.append(f"{label}: Pages workflow must define a push trigger for main")
+    else:
+        push_body = push_match.group("body")
+        if not re.search(r"(?m)^    branches:\s*\[main\]\s*$", push_body):
+            errors.append(f"{label}: Pages push trigger must target main")
+        if re.search(r"(?m)^    paths(?:-ignore)?:\s*$", push_body):
+            errors.append(f"{label}: Pages push trigger must not filter paths after a merge")
+
+    if text.count("group: docs-prysai-production") < 2:
+        errors.append(f"{label}: Docs publication and public verification must share their serialized host group")
+    return errors
+
+
 def validate_codeql_workflow(text: str, label: str) -> list[str]:
     """Keep CodeQL analysis pinned, secret-free, and limited to trusted refs."""
 
@@ -750,6 +786,7 @@ def validate_workflows() -> tuple[int, list[str]]:
         pages_text = PAGES_WORKFLOW.read_text(encoding="utf-8")
         errors.extend(validate_docs_deploy_workflow(pages_text, relative(PAGES_WORKFLOW)))
         errors.extend(validate_pages_candidate_artifact(pages_text, relative(PAGES_WORKFLOW)))
+        errors.extend(validate_pages_post_merge_orchestration(pages_text, relative(PAGES_WORKFLOW)))
     if not CODEQL_WORKFLOW.is_file():
         errors.append("missing .github/workflows/codeql.yml")
     else:

--- a/site/README.md
+++ b/site/README.md
@@ -69,9 +69,10 @@ and high-confidence credential signatures. The project-root entry uses the same
 the local `/site/` route useful for development and prevents static hosts from
 treating fragment navigation as a directory request.
 
-On qualifying pushes to `main`, the workflow builds the artifact and requests
-a GitHub Pages deployment. GitHub Pages must remain enabled in the repository
-settings for the deployment job to publish it. A successful workflow is
+Every push to `main` (including a merged pull request) runs the workflow. It
+builds the artifact and requests a GitHub Pages deployment. GitHub Pages must
+remain enabled in the repository settings for the deployment job to publish
+it. A successful workflow is
 deployment evidence for that run, but it is not proof that the public URL is
 currently reachable to readers, indexed, or ranked; check the deployment URL
 and a fresh HTTP request separately.
@@ -79,18 +80,20 @@ and a fresh HTTP request separately.
 ## Docs mirror
 
 The same bounded artifact is also mirrored to
-`https://docs.prysai.com/llm-playbook/` after a qualifying push to `main`.
+`https://docs.prysai.com/llm-playbook/` after each push to `main`.
 The mirror is served by a restricted deployment account: it accepts a static
 archive only, validates its paths and file types, and atomically changes the
 published release. The deployment key is stored as the protected
 `DOCS_DEPLOY_SSH_KEY` GitHub Environment secret and is never committed here.
 
-The workflow is named **Build and publish Prysai LLM Playbook site**. A
-qualifying push to `main` builds the bounded artifact, deploys it to GitHub
-Pages, and requests the atomic Docs mirror publish. Manual dispatch defaults
-to `deploy: true`; choosing `false` builds only the bounded review artifact.
-The GitHub Pages and Docs mirror jobs are separate observable jobs. A green
-build alone does not prove either public origin now serves the new files.
+The workflow is named **Build and publish Prysai LLM Playbook site**. Every
+push to `main` builds the bounded artifact, deploys it to GitHub
+Pages, syncs the optional Hugging Face Space when `HF_TOKEN` is configured,
+and requests the atomic Docs mirror publish. Manual dispatch defaults to
+`deploy: true`; choosing `false` builds only the bounded review artifact.
+The GitHub Pages, Hugging Face, and Docs mirror jobs are separate observable
+jobs. A green build alone does not prove any public origin now serves the new
+files.
 
 ## Search metadata and public URL
 

--- a/site/README.md
+++ b/site/README.md
@@ -91,9 +91,10 @@ push to `main` builds the bounded artifact, deploys it to GitHub
 Pages, syncs the optional Hugging Face Space when `HF_TOKEN` is configured,
 and requests the atomic Docs mirror publish. Manual dispatch defaults to
 `deploy: true`; choosing `false` builds only the bounded review artifact.
-The GitHub Pages, Hugging Face, and Docs mirror jobs are separate observable
-jobs. A green build alone does not prove any public origin now serves the new
-files.
+GitHub Pages, Hugging Face, and the Docs mirror remain separately observable
+publication surfaces. Docs publication and its public-byte verification run
+sequentially in one protected job. A green build alone does not prove any
+public origin now serves the new files.
 
 ## Search metadata and public URL
 


### PR DESCRIPTION
## Tracking and summary

- Related issue or discussion: None; this is a narrowly scoped follow-up to the post-merge publication concurrency decision recorded in ADR-0051.
- Problem: The Docs public-byte verifier previously ran as a separate job with the same concurrency group as Docs publication. GitHub Actions does not guarantee FIFO ordering across workflow runs, so a newer publication could race with an older verifier.
- Intended outcome: Keep each Docs publication and its matching artifact verification in one protected, sequential job while Pages and Hugging Face remain independently schedulable.
- Scope and intentionally out of scope: Changes only the Pages workflow, its security-policy fixtures, the two related ADRs, and the workflow documentation. Translation, visual, SEO, Wiki, repository settings, automatic approval, merge, and host-side deployment are out of scope.

## Implementation or editorial approach

- Approach: The read-only build job packages `scripts/check_deployed_site.py` as `docs-verifier-${{ github.sha }}`. The protected Docs job downloads that verifier and the matching `pages-candidate-${{ github.sha }}` artifact, publishes the artifact, and verifies the same public bytes immediately afterward.
- Canonical source(s): `.github/workflows/pages.yml` and the repository security-policy validator/fixtures.
- Generated outputs or migration impact: None; the site artifact remains generated by the existing build step.

## Change class

- [ ] Small correction
- [ ] Content change
- [ ] Contract change
- [x] Behavior change
- [ ] Release change
- [ ] Test material (fast route: original fictional fixture or text-only protocol only)

## Contribution route and review request

- Route: [x] Standard review [ ] Fast material review [ ] Restricted evidence intake / do not merge public data
- Receipt or protocol path: not applicable
- Requested reviewer role: maintainer review of workflow permissions, artifact trust boundary, concurrency semantics, and rollback.

## Contribution declaration

- DCO: [x] I have read `DCO.md`, have the right to submit this work, and signed every commit.
- Project license boundary: [x] I accept CC BY 4.0 for project-owned documentation and Apache-2.0 for project-owned scripts/tooling, as applicable.

## Source, authorship, and license

This is original project-owned workflow, validator-fixture, ADR, and documentation work. No third-party text, code, images, or dependencies were copied. The ADR retains official GitHub Actions concurrency, Pages custom-workflow, and `workflow_run` documentation as reference sources (accessed 2026-08-31). No asset-register update is needed.

## Safety and external effects

The workflow touches GitHub Actions scheduling and the protected `docs-prysai-production` deployment path. It retains `actions: read`, fixed-SHA Actions, the existing required environment review, and the artifact-only secret boundary. No new secret, token, permission, host, deletion, or external message is introduced. Rollback is to revert this PR's four commits; the previous workflow remains available in Git history.

## Security review

This is a heightened-review workflow/security-policy change. Maintainers should verify the requested permission boundary, pinned Action sources, same-SHA artifact pairing, protected environment requirement, and rollback before merge. The secret-bearing Docs job still does not check out repository source or rebuild the site.

## AI assistance

- AI assistance used: [x] Yes — AI assisted with repository inspection, concurrency reasoning, wording, and test orchestration. The contributor reviewed the diff, source/license boundary, security implications, and validation results and remains responsible for the submitted work.

## Validation and evidence

- `python -X utf8 scripts/run_tests.py --jobs 4` — `TEST_RUNNER_SUMMARY script_tests=49 passed=50 failed=0`.
- `python -X utf8 scripts/validate_project.py` — `VALIDATION_OK`.
- `python -X utf8 scripts/validate_project_structure.py` — `PROJECT_STRUCTURE_OK`.
- `python -X utf8 scripts/validate_content_completeness.py` — `CONTENT_COMPLETENESS_OK`.
- `python -X utf8 scripts/validate_learning_contract.py --canonical-en` — `LEARNING_CONTRACT_OK`.
- `python -X utf8 scripts/validate_repository_security.py` — `REPOSITORY_SECURITY_POLICY_OK`.
- `python -X utf8 scripts/test_validate_repository_security.py` — `REPOSITORY_SECURITY_POLICY_TESTS_OK fixtures=59`.
- `python -X utf8 scripts/build_pages_artifact.py --check` — `PAGES_ARTIFACT_OK mode=temporary`.
- `git diff --check` — passed.
- Candidate head: `3511de6eebb9986176c36e94110d4d0bcfe8a0aa`; all four commits have valid GitHub cryptographic verification and valid `Signed-off-by` trailers.

## Unverified and out of scope

GitHub-hosted workflow execution, actionlint, the protected environment approval, actual Pages/Docs/Hugging Face publication, live public-byte verification, merge status, and online refresh remain unverified until the PR is reviewed, merged, and a post-merge run completes. This PR does not prove translation quality, learner outcomes, uptime, or production readiness.

## Status claim

Candidate only. Local repository checks and commit-signature evidence pass; this PR does not claim approval, mergeability, deployment, or refreshed public pages.

## Checklist

- [x] I changed the canonical source, not only a generated projection.
- [x] I linked the issue/design context or explained why it is not applicable.
- [x] I kept this PR to one logical change.
- [x] I recorded volatile facts with URL, access date, scope, owner, and next review.
- [x] I registered external assets and license decisions before adaptation.
- [x] I did not commit secrets, credentials, private data, or machine-local configuration.
- [x] I ran the relevant validators and stated what they do not prove.
- [x] I kept translation, runtime, review, and maturity claims honest.
- [ ] For a translation, I kept the same `content_id`, source revision, and same-locale links, and did not call it reviewed without named independent review evidence. (Not applicable.)
- [x] I documented rollback/recovery for contract, behavior, or release changes, or marked it not applicable.
- [x] I added a valid `Signed-off-by: Full Name <email>` line to every commit; the PR check is the source of truth.
- [ ] If this is test material, it is original fictional material with no raw learner work, raw model output, identifiers, consent records, or outcome claim. (Not applicable.)