### PR TITLE
fix(fr): correct platform product agreement

### DIFF
--- a/book/routes/platform-adapter-guide-FR.md
+++ b/book/routes/platform-adapter-guide-FR.md
@@ -5,7 +5,7 @@
 **Statut :** `candidate`. **Exécution :** `not_run`.
 
 ChatGPT, Claude, Gemini, DeepSeek, Grok et Codex dialoguent tous avec vous,
-mais ce ne sont pas le même produit. Cette page conserve le socle commun et
+mais ce ne sont pas les mêmes produits. Cette page conserve le socle commun et
 ajoute un adaptateur à la fois : ce qui diffère réellement, ce que vous pouvez
 essayer sans risque aujourd’hui et ce qu’il faut vérifier dans une source
 officielle avant de reprendre une affirmation propre à une plateforme.


### PR DESCRIPTION
## Tracking and summary

- Related issue or discussion: None; this is a small, unambiguous grammar correction that can be reviewed directly.
- Problem: The French platform-adapter route describes several named platforms as "le même produit", using singular agreement for a plural subject.
- Intended outcome: Use natural French plural agreement without changing the route's meaning, links, status, or platform claims.
- Scope and intentionally out of scope: Only `book/routes/platform-adapter-guide-FR.md` line 8 is changed. No other locale, route, generated site output, deployment, or product fact is in scope.

## Implementation or editorial approach

- Approach: Change `le même produit` to `les mêmes produits` so the article and noun agree with the multiple platforms named in the sentence.
- Canonical source(s): `book/routes/platform-adapter-guide-EN.md` for meaning; `book/routes/platform-adapter-guide-FR.md` for the localized projection.
- Generated outputs or migration impact: Not applicable; this Markdown file is the canonical localized source for this content identity.

## Change class

- [x] Small correction
- [ ] Content change
- [ ] Contract change
- [ ] Behavior change
- [ ] Release change
- [ ] Test material

## Contribution route and review request

- Route: [x] Standard review [ ] Fast material review [ ] Restricted evidence intake / do not merge public data
- Receipt or protocol path: Not applicable.
- Requested reviewer role: Independent French language reviewer; please confirm plural agreement and same-locale context.

## Contribution declaration

- DCO: [x] I have read [`DCO.md`](DCO.md), have the right to submit this work, and signed every commit.
- Project license boundary: [x] I accept CC BY 4.0 for project-owned content or Apache-2.0 for project-owned code/tooling, as applicable.

## Translation details

- Canonical English source and revision: `book/routes/platform-adapter-guide-EN.md` at `2e47712d85c418ba00a03fca0a3ac52278293e41`.
- Target locale and localized file: French (`fr`) — `book/routes/platform-adapter-guide-FR.md`.
- `content_id`: `platform-adapter-guide-route`.
- Terms, paths, commands, URLs, or status labels intentionally kept unchanged: Platform names, `candidate`, `not_run`, file names, paths, links, and `content_id`.
- Machine assistance, if any: AI assisted repository inspection, English/French context comparison, wording proposal, and validation orchestration; no external text or private material was used.
- Translator self-review performed: Blind-first reading of the French paragraph, followed by comparison with the English sentence and neighboring French route copy.
- Independent target-language reviewer requested or recorded: Requested in this PR; no independent review is recorded yet.
- Same-locale navigation checked: Yes; route identity and same-locale links remain unchanged.
- Translation status claimed: `in-progress`; this PR does not promote it.

## Source, authorship, and license

This is an original project-owned editorial correction. No third-party text, code, images, dependencies, or learner data were copied or adapted. No source or asset-register update is needed.

## Safety and external effects

No secrets, credentials, private data, permissions, network calls, publication controls, or external writes are introduced by the content change. The only public effect after merge would be clearer French grammar on this route. Rollback is to revert commit `265af4db47ea3270d85d5c381f8dbdd12e5a270f`.

## Security review

No heightened-review path: this is a reader-facing wording correction with no workflow, script, dependency, credential, deployment, or repository-policy change.

## AI assistance

- AI assistance used: [x] Yes — AI assisted with repository inspection, terminology comparison, wording, and local test orchestration. The contributor remains responsible for source boundaries, accuracy, DCO, and the submitted result.

## Validation and evidence

- `python -X utf8 scripts/check_local_links.py` — `LOCAL_LINKS_OK checked=4610`.
- `python -X utf8 scripts/validate_localization.py` — `LOCALIZATION_OK` (8 locales, 56 content IDs, 448 registered paths).
- `python -X utf8 scripts/validate_learning_contract.py --canonical-en` — `LEARNING_CONTRACT_OK` (22 chapters, 18 Labs).
- `python -X utf8 scripts/validate_content_completeness.py` — `CONTENT_COMPLETENESS_OK`.
- `python -X utf8 scripts/validate_project_structure.py` — `PROJECT_STRUCTURE_OK`.
- `git diff --check` — passed.
- Candidate commit: `265af4db47ea3270d85d5c381f8dbdd12e5a270f`; it has an SSH signature and a `Signed-off-by` trailer.

## Unverified and out of scope

Independent French language review, learner runs, runtime behavior, deployment, online rendering, accessibility beyond existing checks, and production readiness remain unverified. This PR does not claim equal depth across locales, native-level quality, or learner outcomes.

## Status claim

Candidate wording correction only. This PR does not claim approval, mergeability, merge, deployment, equal depth across locales, native-level quality, or learner outcomes.

## Checklist

- [x] I changed the canonical localized source, not a generated projection.
- [x] I explained why no issue/design context is needed for this small correction.
- [x] I kept this PR to one logical change.
- [x] I recorded volatile facts with URL, access date, scope, owner, and next review. (Not applicable; no volatile fact changed.)
- [x] I registered external assets and license decisions before adaptation. (Not applicable; no external asset.)
- [x] I did not commit secrets, credentials, private data, or machine-local configuration.
- [x] I ran the relevant validators and stated what they do not prove.
- [x] I kept translation, runtime, review, and maturity claims honest.
- [x] For a translation, I kept the same `content_id`, source revision, and same-locale links, and did not call it reviewed without named independent review evidence.
- [x] I documented rollback/recovery for contract, behavior, or release changes, or marked it not applicable.
- [x] I added a valid `Signed-off-by: Full Name <email>` line to every commit; the PR check is the source of truth.
- [x] This is not test material; no learner/model data is included.