### PR TITLE
ci: add recurring multilingual coverage audit

### DIFF
--- a/.github/workflows/multilingual-coverage.yml
+++ b/.github/workflows/multilingual-coverage.yml
@@ -1,0 +1,113 @@
+name: Prysai multilingual coverage audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: "29 4 * * 1"
+  workflow_dispatch:
+
+# This workflow is read-only. It records coverage and editorial signals; it
+# does not publish files, change status, or infer native-language quality.
+permissions:
+  contents: read
+
+concurrency:
+  group: multilingual-coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository without persisted credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Run eight-locale coverage and maintenance audits
+        id: audits
+        continue-on-error: true
+        env:
+          AUDIT_DIR: ${{ runner.temp }}/multilingual-coverage
+        run: |
+          set -uo pipefail
+          mkdir -p "$AUDIT_DIR"
+          status=0
+
+          run_audit() {
+            name="$1"
+            shift
+            if "$@" >"$AUDIT_DIR/$name.txt" 2>&1; then
+              echo "AUDIT_OK name=$name"
+            else
+              status=1
+              echo "AUDIT_FAILED name=$name"
+            fi
+            cat "$AUDIT_DIR/$name.txt"
+          }
+
+          run_audit locale-matrix \
+            python -X utf8 scripts/audit_locale_content_matrix.py --fail-on-incomplete
+          run_audit reader-coverage \
+            python -X utf8 scripts/audit_reader_locale_coverage.py \
+            --fail-on-invalid --fail-on-not-started
+          run_audit semantic-contract \
+            python -X utf8 scripts/audit_semantic_contract.py --deep \
+            --fail-on-missing --fail-on-deep-missing --fail-on-structure-missing
+          run_audit localization \
+            python -X utf8 scripts/validate_localization.py
+          run_audit book-navigation \
+            python -X utf8 scripts/validate_book_navigation.py
+          run_audit textbook-entry-path \
+            python -X utf8 scripts/validate_textbook_entry_path.py
+          run_audit content-completeness \
+            python -X utf8 scripts/validate_content_completeness.py
+          run_audit learning-contract \
+            python -X utf8 scripts/validate_learning_contract.py --canonical-en
+          run_audit update-registry \
+            python -X utf8 scripts/validate_update_registry.py
+          run_audit local-links \
+            python -X utf8 scripts/check_local_links.py
+          run_audit translation-signals \
+            python -X utf8 scripts/audit_translation_language_quality.py --verbose
+
+          exit "$status"
+
+      - name: Upload multilingual audit reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: multilingual-coverage-${{ github.sha }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/multilingual-coverage
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish audit summary
+        if: always()
+        env:
+          AUDIT_DIR: ${{ runner.temp }}/multilingual-coverage
+        run: |
+          {
+            echo "## Multilingual coverage audit"
+            echo
+            echo "This run checks eight-locale route/file identity, Reader coverage, semantic contracts, navigation, links, and translation-language signals. It does not establish native-level quality, independent review, learner outcomes, runtime behavior, or release readiness."
+            for report in "$AUDIT_DIR"/*.txt; do
+              [ -f "$report" ] || continue
+              echo
+              echo "### $(basename "$report")"
+              grep -E '^(LOCALE_|READER_|SEMANTIC_|LOCALIZATION_|BOOK_|TEXTBOOK_|CONTENT_|LEARNING_|VALIDATION_|LOCAL_LINKS_|TRANSLATION_)' "$report" | tail -n 4 || tail -n 4 "$report"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce audit results
+        if: steps.audits.outcome != 'success'
+        run: exit 1

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -10,6 +10,7 @@ book, site, translations, status, and maintenance records aligned.
 | Add or reorder a chapter | [`book-navigation.yaml`](book-navigation.yaml) | Chapter footers and TOCs |
 | Add or reorder a Lab in catalog navigation | [`lab-navigation.yaml`](lab-navigation.yaml) | English Lab footers and Reader pagination; learning progression remains separate |
 | Change a locale identity or translation state | [`locale-matrix.yaml`](locale-matrix.yaml) | Localized links and migration checks |
+| Run the recurring multilingual coverage audit | [`update-registry.yaml`](update-registry.yaml), [workflow](../../.github/workflows/multilingual-coverage.yml) | Eight-locale route/file identity, Reader coverage, semantic contracts, navigation, links, and translation-language signals |
 | Change which chapters/labs can be routed by the public site | [`content-status.yaml`](content-status.yaml) | Regenerate [`site/locale-manifest.js`](../../site/locale-manifest.js) |
 | Change a learning level | [`learning-path.yaml`](learning-path.yaml) | Site data and learning-path validator |
 | Change the beginner course promise or default scope | [`../product/core-course-contract.md`](../product/core-course-contract.md) and [`core-release-scope.md`](core-release-scope.md) | Core-course route, inventory, rubric, and focused validator |

--- a/docs/governance/update-registry.yaml
+++ b/docs/governance/update-registry.yaml
@@ -124,6 +124,16 @@
       "next_review": "2026-09-12"
     },
     {
+      "area": "multilingual-coverage",
+      "canonical_paths": [".github/workflows/multilingual-coverage.yml", "docs/governance/locale-matrix.yaml", "docs/governance/content-status.yaml", "docs/governance/book-navigation.yaml", "docs/governance/lab-navigation.yaml", "scripts/audit_locale_content_matrix.py", "scripts/audit_reader_locale_coverage.py", "scripts/audit_semantic_contract.py", "scripts/validate_localization.py", "scripts/validate_book_navigation.py", "scripts/validate_textbook_entry_path.py", "scripts/validate_content_completeness.py", "scripts/validate_learning_contract.py", "scripts/check_local_links.py", "scripts/audit_translation_language_quality.py"],
+      "owner": "localization-maintainer",
+      "triggers": ["locale-file-change", "locale-matrix-change", "navigation-change", "content-status-change", "translation-review-cycle"],
+      "required_inputs": ["locale-matrix", "reader-coverage", "semantic-contract", "navigation", "link-check", "translation-status", "audit-run-id"],
+      "validation_commands": ["scripts/audit_locale_content_matrix.py --fail-on-incomplete", "scripts/audit_reader_locale_coverage.py --fail-on-invalid --fail-on-not-started", "scripts/audit_semantic_contract.py --deep --fail-on-missing --fail-on-deep-missing --fail-on-structure-missing", "scripts/validate_localization.py", "scripts/validate_book_navigation.py", "scripts/validate_textbook_entry_path.py", "scripts/validate_content_completeness.py", "scripts/validate_learning_contract.py --canonical-en", "scripts/check_local_links.py", "scripts/audit_translation_language_quality.py --verbose"],
+      "status_fields": ["audit_status", "coverage_status", "semantic_status", "translation_status", "owner", "last_run", "next_review"],
+      "next_review": "2026-09-09"
+    },
+    {
       "area": "repository-security",
       "canonical_paths": ["SECURITY.md", "DCO.md", "docs/governance/repository-security-policy.yaml", ".github/workflows/security-policy.yml", ".github/workflows/codeql.yml", ".github/workflows/pull-request-contract.yml", ".github/workflows/maintainer-pr-automerge.yml", ".github/PULL_REQUEST_TEMPLATE.md", "site/index.html", "site/reader.html", "site/reader.js", "scripts/validate_repository_security.py", "scripts/test_validate_repository_security.py", "scripts/test_validate_github_templates.py", "docs/adr/0036-repository-security-policy-and-pr-gate.md", "docs/adr/0043-expand-repository-sensitive-information-tripwires.md", "docs/adr/0044-live-host-security-controls-and-publishing-boundaries.md", "docs/adr/0045-deploy-only-validated-pages-artifact.md", "docs/adr/0046-reader-source-boundary-and-codeql-v4.md", "docs/adr/0047-post-mutation-host-boundary-receipt.md", "docs/adr/0049-maintainer-only-release-controls.md", "docs/adr/0050-constrained-maintainer-documentation-auto-merge.md", "docs/security/sensitive-information-audit-2026-08-18.md"],
       "owner": "governance-maintainer",


### PR DESCRIPTION
## Tracking and summary

- Related issue or discussion (or rationale for none): No issue; this is a focused maintenance-capability change requested to keep the eight-locale documentation auditable over time.
- Problem: Locale coverage and semantic-contract checks exist as local scripts, but no recurring GitHub workflow runs them after merges and on a scheduled review cycle.
- Intended outcome: Run the same read-only coverage, Reader, semantic-contract, navigation, link, localization, and translation-signal checks on `main`, pull requests, and a weekly schedule, with retained reports.
- Scope and intentionally out of scope: Adds one workflow and its governance references. It does not translate content, change locale status, publish pages, or promote any maturity claim.

## Implementation or editorial approach

- Approach: Reuse existing validators as independent commands, capture each report, fail the job on any failed audit, upload the reports, and state the evidence boundary in the job summary.
- Canonical source(s): `.github/workflows/multilingual-coverage.yml` and `docs/governance/update-registry.yaml`.
- Generated outputs or migration impact (or `not applicable`): Not applicable; no generated projection is changed.

## Change class

- [ ] Small correction
- [ ] Content change
- [ ] Contract change
- [ ] Behavior change
- [x] Release change
- [ ] Test material (fast route: original fictional fixture or text-only protocol only)

## Contribution route and review request

- Route: [x] Standard review [ ] Fast material review [ ] Restricted evidence intake / do not merge public data
- Receipt or protocol path (or `not applicable`): Not applicable.
- Requested reviewer role: Repository maintainer, security reviewer, and localization maintainer.

## Contribution declaration

- DCO: [x] I have read [`DCO.md`](DCO.md), have the right to submit this work, and signed every commit.
- Project license boundary: [x] I accept CC BY 4.0 for project-owned content or Apache-2.0 for project-owned code/tooling, as applicable.

## Source, authorship, and license

The workflow and governance wording are original project-authored work. The workflow uses the repository's existing pinned GitHub Actions and does not copy external text, code, images, or data. Project-owned workflow/configuration remains under the repository's Apache-2.0/code-tooling boundary; documentation wording remains under the documented CC BY 4.0 boundary.

## Safety and external effects

The workflow requests only `contents: read`, uses `persist-credentials: false`, and does not use secrets, write tokens, external messages, deployment, deletion, or PR mutation. It uploads audit reports as ordinary workflow artifacts with a 30-day retention period. The weekly schedule and `push`/PR triggers are the only external execution effects.

## Security review

This is a heightened-review workflow change. The job executes checked-in validators with a read-only token, does not check out or execute privileged PR code, and uses the same pinned action SHAs already approved by repository policy. Rollback is a one-commit revert of `3223fefb494a0f92a48e72e2446c2bfa566bb716`; maintainer and security review are requested.

## AI assistance

- AI assistance used: [x] Yes — AI helped design and draft the workflow and governance entry; the contributor reviewed the existing contracts, permissions, action pins, shell behavior, scope, and validation output.

## Validation and evidence

- `python -X utf8 scripts/validate_update_registry.py` — `VALIDATION_OK registry=docs\\governance\\update-registry.yaml areas=21`.
- `python -X utf8 scripts/validate_repository_security.py` — `REPOSITORY_SECURITY_POLICY_OK workflows=10 candidate_files=1620 host_ruleset=active`.
- `python -X utf8 scripts/test_validate_repository_security.py` — `REPOSITORY_SECURITY_POLICY_TESTS_OK fixtures=59`.
- `python -X utf8 scripts/validate_github_templates.py` and `python -X utf8 scripts/test_validate_github_templates.py` — both passed.
- `python -X utf8 scripts/run_tests.py --jobs 4` — `TEST_RUNNER_SUMMARY script_tests=49 passed=50 failed=0`.
- `python -X utf8 scripts/build_release_evidence.py --check` — `RELEASE_EVIDENCE_CONTRACT_OK dimensions=6 commands=96`.
- Focused eight-locale audit — locale matrix `56/56` in all locales, Reader `103` identities with no missing/not-started routes, semantic `missing_contract=0`, navigation/localization/content/link checks passed.
- Workflow YAML parsed successfully with PyYAML. Candidate commit: `3223fefb494a0f92a48e72e2446c2bfa566bb716`, signed with the configured SSH signing key and containing `Signed-off-by: uuzzrm <uuzzrm@users.noreply.github.com>`.

## Unverified and out of scope

The scheduled GitHub-hosted run has not yet executed for this new workflow, so hosted-run duration, artifact upload, and summary rendering remain unverified until GitHub runs it. The audits do not prove native-level translation quality, independent language review, learner outcomes, runtime behavior, security outcomes, or release readiness.

## Status claim

No maturity, translation, release, or fact-status change. All non-English content remains `candidate`/`in-progress` as declared by the existing governance sources.

## Checklist

- [x] I changed the canonical source, not only a generated projection.
- [x] I linked the issue/design context or explained why it is not applicable.
- [x] I kept this PR to one logical change.
- [x] I recorded volatile facts with URL, access date, scope, owner, and next review.
- [x] I registered external assets and license decisions before adaptation.
- [x] I did not commit secrets, credentials, private data, or machine-local configuration.
- [x] I ran the relevant validators and stated what they do not prove.
- [x] I kept translation, runtime, review, and maturity claims honest.
- [x] I documented rollback/recovery for contract, behavior, or release changes, or marked it not applicable.
- [x] I added a valid `Signed-off-by: Full Name <email>` line to every commit; the PR check is the source of truth.
- [x] If this is test material, it is original fictional material with no raw learner work, raw model output, identifiers, consent records, or outcome claim.