### PR TITLE
fix(governance): accept verified main branch sync commits

### DIFF
--- a/.github/workflows/pull-request-contract.yml
+++ b/.github/workflows/pull-request-contract.yml
@@ -47,6 +47,8 @@ jobs:
           expected_head = os.environ["EXPECTED_HEAD_SHA"]
           created_at = pull_request.get("created_at")
           legacy_authors = {"uuzzrm", "Prysai-Lab"}
+          branch_sync_authors = {"uuzzrm", "Prysai-Lab"}
+          branch_sync_committer = "web-flow"
 
           def fail(message):
               print("PR_CONTRACT_FAILED")
@@ -122,12 +124,40 @@ jobs:
 
           signoff = re.compile(r"^Signed-off-by:\s+[^<>\r\n]+<[^<>\s]+@[^<>\s]+>\s*$", re.IGNORECASE)
           signoff_prefix = re.compile(r"^Signed-off-by:", re.IGNORECASE)
+          branch_sync_headline = re.compile(r"^Merge branch 'main' into .+$")
+
+          def is_trusted_branch_sync_commit(commit):
+              verification = (commit.get("commit") or {}).get("verification") or {}
+              author = commit.get("author") or {}
+              committer = commit.get("committer") or {}
+              parents = commit.get("parents") or []
+              base = pull_request.get("base") or {}
+              message = ((commit.get("commit") or {}).get("message") or "")
+              headline = message.splitlines()[0] if message.splitlines() else ""
+              return (
+                  pull_request.get("user", {}).get("login") in branch_sync_authors
+                  and base.get("ref") == "main"
+                  and (base.get("repo") or {}).get("full_name") == os.environ.get("GITHUB_REPOSITORY")
+                  and isinstance(base.get("sha"), str)
+                  and len(parents) == 2
+                  and parents[1].get("sha") == base.get("sha")
+                  and author.get("login") in branch_sync_authors
+                  and committer.get("login") == branch_sync_committer
+                  and verification.get("verified") is True
+                  and verification.get("reason") == "valid"
+                  and branch_sync_headline.fullmatch(headline)
+              )
+
           failures = []
+          branch_sync_exemptions = []
           for commit in commits:
               sha = commit.get("sha", "unknown")
               message = ((commit.get("commit") or {}).get("message") or "")
               lines = message.splitlines()
               declared = [line for line in lines if signoff_prefix.match(line)]
+              if not declared and is_trusted_branch_sync_commit(commit):
+                  branch_sync_exemptions.append(sha[:12])
+                  continue
               valid = [line for line in declared if signoff.fullmatch(line)]
               if not valid or len(valid) != len(declared):
                   failures.append(sha[:12])
@@ -137,5 +167,8 @@ jobs:
                   "and no malformed sign-off; failures: " + ", ".join(failures)
               )
 
-          print(f"PR_CONTRACT_OK commits={len(commits)} headings={len(required_headings)} head={expected_head[:12]}")
+          print(
+              f"PR_CONTRACT_OK commits={len(commits)} headings={len(required_headings)} "
+              f"branch_sync_exemptions={len(branch_sync_exemptions)} head={expected_head[:12]}"
+          )
           PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,11 @@ State all of the following in the pull request:
 
 The pull-request template is paired with the read-only `pull-request-contract`
 workflow. For new PRs, that check verifies the required disclosure headings,
-the exact PR head SHA it inspected, and a valid DCO sign-off on every commit.
+the exact PR head SHA it inspected, and a valid DCO sign-off on every
+contributor commit. The only DCO exception is a GitHub-generated,
+cryptographically verified `main` branch-sync merge commit by the explicitly
+trusted maintainer accounts, with `web-flow` as committer and the current base
+SHA as its second parent; ordinary merge commits still need a DCO trailer.
 PRs opened before the one-time rollout cutoff (`2026-08-31T00:14:52Z`, when PR
 #66 was merged) use a migration path that still verifies the current head,
 non-empty commit history, and a valid GitHub cryptographic signature on every

--- a/DCO.md
+++ b/DCO.md
@@ -6,8 +6,8 @@ contributions. The canonical DCO text is maintained at
 text, and this file is not legal advice.
 
 For pull requests created on or after the repository contract rollout, adding
-the following trailer to every commit makes the certification described by the
-DCO:
+the following trailer to every contributor commit makes the certification
+described by the DCO:
 
 ```text
 Signed-off-by: Full Name <email@example.com>
@@ -15,12 +15,15 @@ Signed-off-by: Full Name <email@example.com>
 
 Use `git commit -s` when creating or amending a commit. The repository's
 `pull-request-contract` check reads every commit in new pull requests and
-fails when a commit has no valid sign-off. A checked box in the pull request
-body is not evidence by itself. Pull requests opened before the one-time
-contract rollout cutoff (`2026-08-31T00:14:52Z`, when PR #66 was merged) use a
-limited migration path that requires GitHub to report a valid cryptographic
-signature on every commit; that exception does not certify or rewrite their
-historical DCO trailers or commit messages.
+fails when a contributor commit has no valid sign-off. The only narrow
+exception is a GitHub-generated, cryptographically verified `main` branch-sync
+merge commit authored by `uuzzrm` or `Prysai-Lab` and committed by `web-flow`,
+whose second parent is the PR's current base SHA. A checked box in the pull
+request body is not evidence by itself. Pull requests opened before the
+one-time contract rollout cutoff (`2026-08-31T00:14:52Z`, when PR #66 was
+merged) use a limited migration path that requires GitHub to report a valid
+cryptographic signature on every commit; that exception does not certify or
+rewrite their historical DCO trailers or commit messages.
 
 The DCO sign-off is separate from a verified GitHub commit signature. A verified
 SSH, GPG, or S/MIME signature proves control of a signing key; it does not

--- a/docs/adr/0050-constrained-maintainer-documentation-auto-merge.md
+++ b/docs/adr/0050-constrained-maintainer-documentation-auto-merge.md
@@ -51,6 +51,15 @@ The workflow may act only when all of the following are true:
 5. the quality, security, and pull-request contract workflows completed
    successfully for that exact SHA.
 
+The pull-request contract requires a valid DCO trailer on every contributor
+commit. It has one narrowly defined exception for a GitHub-generated,
+cryptographically verified merge made while updating a trusted maintainer PR
+from `main`: the commit must be authored by `uuzzrm` or `Prysai-Lab`, committed
+by `web-flow`, have the current base SHA as its second parent, and use GitHub's
+`Merge branch 'main' into <branch>` headline. This recognizes the host's
+branch-update operation without treating an arbitrary signed merge commit as a
+DCO declaration.
+
 After the eligibility checks, the workflow submits a clearly labeled bot
 approval if the current head lacks one, re-reads the PR to confirm that the
 identity and exact head SHA have not changed, then requests GitHub's native
@@ -118,7 +127,10 @@ This ADR records a proposed repository design. Local static validation and
 fixture tests establish only the declared source contract. The migration path
 was added after the #66 rollout was observed to block pre-existing PRs. It
 requires a valid GitHub cryptographic signature on every historical commit but
-does not certify missing DCO trailers or rewrite commit messages. It has
+does not certify missing DCO trailers or rewrite commit messages. The strict
+path now has a narrow, host-generated branch-sync exception: it does not waive
+DCO for ordinary merge commits, and it still requires the Ruleset's signed
+commit rule. It has
 not yet been runtime-tested from `main` against the full set of open PRs, and
 the new strict path has not yet been validated by a newly created eligible PR.
 Live GitHub settings may drift and must be rechecked before treating the route

--- a/docs/governance/repository-security-policy.yaml
+++ b/docs/governance/repository-security-policy.yaml
@@ -69,7 +69,7 @@
       "secret-bearing Docs deployment consumes only the validated Pages artifact",
       "post-merge Pages, Docs, and Hugging Face publication jobs keep independent concurrency boundaries",
       "policy fixture tests, including synthetic-path false-positive boundaries",
-      "read-only pull-request contract headings, exact-head check, and per-commit DCO sign-offs",
+      "read-only pull-request contract headings, exact-head check, per-contributor-commit DCO sign-offs, and the narrow verified GitHub branch-sync exception",
       "maintainer documentation auto-merge workflow boundary and permission exception"
     ],
     "evidence_limit": "A passing check only establishes the declared static policy over the checked commit. It does not prove that no secret, vulnerability, unsafe dependency, account compromise, deployment risk, or host-side misconfiguration exists."
@@ -80,12 +80,12 @@
       "source and license disclosure",
       "safety and external-effect disclosure",
       "pull-request contract headings and exact-head check",
-      "valid DCO sign-off on every commit",
+      "valid DCO sign-off on every contributor commit, with only the verified GitHub main-branch sync merge exception",
       "commands and evidence actually produced",
       "unverified scope"
     ],
     "migration_exceptions": [
-      "Pull requests created before 2026-08-31T00:14:52Z by uuzzrm or Prysai-Lab may use the one-time contract migration path: the exact current head, non-empty commit history, and a valid GitHub cryptographic signature on every commit remain required, while historical PR headings and DCO trailers are not retroactively rewritten. The active Ruleset, required checks, resolved threads, and maintainer approval remain required."
+      "Pull requests created before 2026-08-31T00:14:52Z by uuzzrm or Prysai-Lab may use the one-time contract migration path: the exact current head, non-empty commit history, and a valid GitHub cryptographic signature on every commit remain required, while historical PR headings and DCO trailers are not retroactively rewritten. New PRs may omit a DCO trailer only on a GitHub-generated, cryptographically verified main-branch sync merge commit authored by uuzzrm or Prysai-Lab, committed by web-flow, and carrying the current base SHA as its second parent; ordinary merge commits remain subject to DCO. The active Ruleset, required checks, resolved threads, and maintainer approval remain required."
     ],
     "heightened_review_paths": [
       ".github/workflows/**",

--- a/scripts/test_validate_repository_security.py
+++ b/scripts/test_validate_repository_security.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-import tempfile
 import copy
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
 from pathlib import Path
 
 import validate_repository_security as policy
@@ -12,6 +16,99 @@ import validate_repository_security as policy
 def require(condition: bool, message: str) -> None:
     if not condition:
         raise AssertionError(message)
+
+
+def run_contract_fixture(
+    *,
+    sync_author: str = "Prysai-Lab",
+    sync_committer: str = "web-flow",
+    sync_parent: str = "base-sha",
+) -> subprocess.CompletedProcess[str]:
+    workflow = policy.PULL_REQUEST_CONTRACT_WORKFLOW.read_text(encoding="utf-8")
+    marker = "          python - \"$RUNNER_TEMP/pull-request.json\" \"$RUNNER_TEMP/pull-request-commits.json\" <<'PY'\n"
+    start = workflow.index(marker) + len(marker)
+    end = workflow.index("          PY\n", start)
+    contract_script = textwrap.dedent(workflow[start:end])
+    headings = [
+        "## Tracking and summary",
+        "## Implementation or editorial approach",
+        "## Change class",
+        "## Contribution route and review request",
+        "## Contribution declaration",
+        "## Source, authorship, and license",
+        "## Safety and external effects",
+        "## Security review",
+        "## AI assistance",
+        "## Validation and evidence",
+        "## Unverified and out of scope",
+        "## Status claim",
+        "## Checklist",
+    ]
+    pull_request = {
+        "created_at": "2026-09-01T00:00:00Z",
+        "user": {"login": "uuzzrm"},
+        "head": {"sha": "head-sha"},
+        "base": {
+            "ref": "main",
+            "sha": "base-sha",
+            "repo": {"full_name": "Prysai/Prysai-LLM-Playbook"},
+        },
+        "body": "\n".join(headings),
+    }
+    commits = [
+        {
+            "sha": "contributor-sha",
+            "author": {"login": "uuzzrm"},
+            "committer": {"login": "uuzzrm"},
+            "commit": {
+                "message": "docs: fixture\n\nSigned-off-by: uuzzrm <uuzzrm@users.noreply.github.com>",
+                "verification": {"verified": True, "reason": "valid"},
+            },
+            "parents": [{"sha": "base-sha"}],
+        },
+        {
+            "sha": "sync-sha",
+            "author": {"login": sync_author},
+            "committer": {"login": sync_committer},
+            "commit": {
+                "message": "Merge branch 'main' into uuzzrm/fixture",
+                "verification": {"verified": True, "reason": "valid"},
+            },
+            "parents": [
+                {"sha": "contributor-sha"},
+                {"sha": sync_parent},
+            ],
+        },
+    ]
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        pull_request_path = root / "pull-request.json"
+        commits_path = root / "pull-request-commits.json"
+        pull_request_path.write_text(json.dumps(pull_request), encoding="utf-8")
+        commits_path.write_text(json.dumps([commits]), encoding="utf-8")
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "EXPECTED_HEAD_SHA": "head-sha",
+                "ROLLOUT_CUTOFF_AT": "2026-08-31T00:14:52Z",
+                "GITHUB_REPOSITORY": "Prysai/Prysai-LLM-Playbook",
+                "PR_NUMBER": "999",
+            }
+        )
+        return subprocess.run(
+            [
+                os.fspath(Path(os.sys.executable)),
+                "-c",
+                contract_script,
+                os.fspath(pull_request_path),
+                os.fspath(commits_path),
+            ],
+            cwd=policy.ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
 
 def main() -> int:
@@ -345,6 +442,40 @@ permissions:
             and "legacy migration requires a valid GitHub cryptographic signature" in pull_request_contract
             and "PR_CONTRACT_MIGRATION_OK" in pull_request_contract,
             "pull-request contract did not retain the bounded legacy migration gate",
+        )
+        fixtures += 1
+
+        require(
+            "branch_sync_authors = {\"uuzzrm\", \"Prysai-Lab\"}" in pull_request_contract
+            and "branch_sync_committer = \"web-flow\"" in pull_request_contract
+            and "parents[1].get(\"sha\") == base.get(\"sha\")" in pull_request_contract
+            and "and committer.get(\"login\") == branch_sync_committer" in pull_request_contract
+            and "branch_sync_headline = re.compile" in pull_request_contract
+            and "branch_sync_exemptions" in pull_request_contract,
+            "pull-request contract did not retain the narrow signed branch-sync DCO exception",
+        )
+        fixtures += 1
+
+        branch_sync = run_contract_fixture()
+        require(
+            branch_sync.returncode == 0
+            and "PR_CONTRACT_OK" in branch_sync.stdout
+            and "branch_sync_exemptions=1" in branch_sync.stdout,
+            "verified GitHub main branch-sync merge was not accepted as the narrow DCO exception",
+        )
+        fixtures += 1
+
+        untrusted_branch_sync = run_contract_fixture(sync_committer="attacker")
+        require(
+            untrusted_branch_sync.returncode != 0 and "failures: sync-sha" in untrusted_branch_sync.stdout,
+            "arbitrary signed branch-sync-shaped merge was accepted without a DCO trailer",
+        )
+        fixtures += 1
+
+        stale_branch_sync = run_contract_fixture(sync_parent="different-base-sha")
+        require(
+            stale_branch_sync.returncode != 0 and "failures: sync-sha" in stale_branch_sync.stdout,
+            "branch-sync merge for a different base was accepted without a DCO trailer",
         )
         fixtures += 1
 

--- a/scripts/validate_repository_security.py
+++ b/scripts/validate_repository_security.py
@@ -313,6 +313,12 @@ PULL_REQUEST_CONTRACT_REQUIRED_FRAGMENTS = (
     "verification.get(\"reason\") != \"valid\"",
     "legacy migration requires a valid GitHub cryptographic signature",
     "PR_CONTRACT_MIGRATION_OK",
+    "branch_sync_authors = {\"uuzzrm\", \"Prysai-Lab\"}",
+    "branch_sync_committer = \"web-flow\"",
+    "parents[1].get(\"sha\") == base.get(\"sha\")",
+    "and committer.get(\"login\") == branch_sync_committer",
+    "branch_sync_headline = re.compile",
+    "branch_sync_exemptions",
     "PR_CONTRACT_OK",
 )
 


### PR DESCRIPTION
## Tracking and summary

- Related issue or discussion (or rationale for none): Existing Prysai PR contract and maintainer auto-merge behavior; no separate issue.
- Problem: GitHub's maintainer "Update branch" operation creates a cryptographically verified, two-parent `web-flow` merge commit without a DCO trailer. The contract treated that host-generated synchronization commit like a contributor commit, blocking otherwise valid maintainer PRs.
- Intended outcome: Accept only the narrowly identifiable GitHub-generated `main` branch-sync commit while preserving DCO for contributor commits and ordinary merges.
- Scope and intentionally out of scope: Contract workflow, its security fixtures, DCO/contributor guidance, and governance/ADR wording only. No content, Ruleset, approval, bypass, merge, or deployment behavior is changed.

## Implementation or editorial approach

- Approach: Require the trusted maintainer author set, `web-flow` committer, valid GitHub cryptographic signature, exact two-parent shape, current base SHA as second parent, `main` base, and GitHub's branch-sync headline before exempting one commit from the DCO trailer check.
- Canonical source(s): `.github/workflows/pull-request-contract.yml`, `scripts/validate_repository_security.py`, and `scripts/test_validate_repository_security.py`.
- Generated outputs or migration impact (or `not applicable`): Not applicable.

## Change class

- [ ] Small correction
- [ ] Content change
- [x] Contract change
- [ ] Behavior change
- [ ] Release change
- [ ] Test material (fast route: original fictional fixture or text-only protocol only)

## Contribution route and review request

- Route: [x] Standard review [ ] Fast material review [ ] Restricted evidence intake / do not merge public data
- Receipt or protocol path (or `not applicable`): Not applicable.
- Requested reviewer role: Maintainer/security reviewer familiar with GitHub Actions, DCO, Rulesets, and workflow_run boundaries.

## Contribution declaration

- DCO: [x] I have read [`DCO.md`](DCO.md), have the right to submit this work, and signed every commit.
- Project license boundary: [x] I accept CC BY 4.0 for project-owned content or Apache-2.0 for project-owned code/tooling, as applicable.

## Source, authorship, and license

This is an original governance correction based on the repository's existing workflow and live GitHub commit metadata. No external text, image, code, or skill instructions were copied or adapted. The changed governance and code files remain under the repository's documented content/code license boundaries.

## Safety and external effects

This PR changes only a read-only PR metadata check and its documentation/tests. It adds no token, secret, dependency, external network call, deployment, approval, merge, bypass, or permission. The workflow remains read-only. Rollback is a one-commit revert of `4314a4f30aa8283fa00b143070cfbe850c3a20ff`.

## Security review

Heightened review is required because this PR changes `.github/workflows/**`, `scripts/**`, DCO guidance, and repository security governance. The exception is fail-closed: it requires the explicit author set, `web-flow`, a valid cryptographic signature, `main`, the current base SHA as the second parent, exactly two parents, and the expected GitHub headline. Ordinary commits and arbitrary merge commits still require a valid DCO trailer.

## AI assistance

- AI assistance used: [x] Yes — AI assisted with diagnosis, implementation, fixture design, and validation. The contributor reviewed the exact diff, source boundary, security predicates, and test evidence and remains responsible for the submission.

## Validation and evidence

- `python -X utf8 scripts/test_validate_repository_security.py` -> `REPOSITORY_SECURITY_POLICY_TESTS_OK fixtures=63`.
- `python -X utf8 scripts/validate_repository_security.py` -> `REPOSITORY_SECURITY_POLICY_OK workflows=10 candidate_files=1620 host_ruleset=active`.
- `python -X utf8 scripts/validate_project.py` -> `VALIDATION_OK required_files=146`.
- `python -X utf8 scripts/validate_project_structure.py` -> `PROJECT_STRUCTURE_OK`.
- `python -X utf8 scripts/validate_content_completeness.py` -> `CONTENT_COMPLETENESS_OK`.
- `python -X utf8 scripts/validate_learning_contract.py --canonical-en` -> `LEARNING_CONTRACT_OK chapters=22 labs=18`.
- `python -X utf8 scripts/validate_github_templates.py` -> `GITHUB_TEMPLATES_OK issue_forms=5 pr_headings=13 field_labels=1 remote=not_checked`.
- `python -X utf8 scripts/build_release_evidence.py --check` -> `RELEASE_EVIDENCE_CONTRACT_OK dimensions=6 commands=96`.
- `python -X utf8 scripts/run_tests.py --jobs 4` -> `TEST_RUNNER_SUMMARY script_tests=49 passed=50 failed=0`.
- `git diff --check` -> passed.
- Real GitHub API replay of PR #73, #75, #76, and #78 -> `PR_CONTRACT_OK` for each; each recognized exactly one `branch_sync_exemption`.
- Candidate commit: `4314a4f30aa8283fa00b143070cfbe850c3a20ff`; GitHub reports `verified=true`, `reason=valid`, and a valid DCO trailer.

## Unverified and out of scope

This PR does not prove that the host will merge the existing content PRs before this governance fix is merged. It does not alter or bypass the active Ruleset, add approvals, resolve threads, repair conflicts, rerun third-party CI, or claim content quality, translation quality, deployment, release, or production readiness. After merge, the four existing Prysai content PRs must be rechecked at their new head/check state.

## Status claim

This is a candidate governance fix. It requests no maturity, release, or publication status change.

## Checklist

- [x] I changed the canonical source, not only a generated projection.
- [x] I linked the issue/design context or explained why it is not applicable.
- [x] I kept this PR to one logical change.
- [x] I recorded volatile facts with URL, access date, scope, owner, and next review.
- [x] I registered external assets and license decisions before adaptation (no external assets in this change).
- [x] I did not commit secrets, credentials, private data, or machine-local configuration.
- [x] I ran the relevant validators and stated what they do not prove.
- [x] I kept translation, runtime, review, and maturity claims honest.
- [x] I documented rollback/recovery for contract, behavior, or release changes, or marked it not applicable.
- [x] I added a valid `Signed-off-by: Full Name <email>` line to every commit; the PR check is the source of truth.
- [x] If this is test material, it is original fictional material with no raw learner work, raw model output, identifiers, consent records, or outcome claim (not applicable).